### PR TITLE
Feat: Add new data quality button

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-02-16T08:28:36.419Z\n"
-"PO-Revision-Date: 2024-02-16T08:28:36.420Z\n"
+"POT-Creation-Date: 2024-02-27T13:27:38.303Z\n"
+"PO-Revision-Date: 2024-02-27T13:27:38.304Z\n"
 
 msgid "Add"
 msgstr ""
@@ -80,6 +80,12 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
+msgid "Module 1"
+msgstr ""
+
+msgid "Module 2"
+msgstr ""
+
 msgid "Dataset"
 msgstr ""
 
@@ -90,6 +96,15 @@ msgid "End Date"
 msgstr ""
 
 msgid "Status"
+msgstr ""
+
+msgid "New Data Quality"
+msgstr ""
+
+msgid "Selected element deleted successfully"
+msgstr ""
+
+msgid "Status changed"
 msgstr ""
 
 msgid "Start analysis"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2024-02-16T08:28:36.419Z\n"
+"POT-Creation-Date: 2024-02-27T13:27:38.303Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -80,6 +80,12 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
+msgid "Module 1"
+msgstr ""
+
+msgid "Module 2"
+msgstr ""
+
 msgid "Dataset"
 msgstr ""
 
@@ -90,6 +96,15 @@ msgid "End Date"
 msgstr ""
 
 msgid "Status"
+msgstr ""
+
+msgid "New Data Quality"
+msgstr ""
+
+msgid "Selected element deleted successfully"
+msgstr ""
+
+msgid "Status changed"
 msgstr ""
 
 msgid "Start analysis"

--- a/src/webapp/components/empty-state/EmptyState.tsx
+++ b/src/webapp/components/empty-state/EmptyState.tsx
@@ -1,6 +1,5 @@
 import Typography from "@material-ui/core/Typography";
 import styled, { css } from "styled-components";
-import i18n from "$/utils/i18n";
 import React from "react";
 import customTheme from "$/webapp/pages/app/themes/customTheme";
 
@@ -16,7 +15,7 @@ export type ContainerProps = {
 export const EmptyState: React.FC<Props> = React.memo(({ message, variant }) => {
     return (
         <Container $variant={variant}>
-            <Typography>{i18n.t(message)}</Typography>
+            <Typography>{message}</Typography>
         </Container>
     );
 });

--- a/src/webapp/components/menu-button/MenuButton.tsx
+++ b/src/webapp/components/menu-button/MenuButton.tsx
@@ -8,15 +8,15 @@ import styled from "styled-components";
 type Item = {
     label: string;
     id: string;
+    handleClick: () => void;
 };
 
 type Props = {
     label: string;
     items: Item[];
-    handleClick: () => void;
 };
 
-export const MenuButton: React.FC<Props> = memo(({ label, items, handleClick }) => {
+export const MenuButton: React.FC<Props> = memo(({ label, items }) => {
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
     const onOpenMenu = (event: MouseEvent<HTMLButtonElement>) => {
@@ -46,8 +46,8 @@ export const MenuButton: React.FC<Props> = memo(({ label, items, handleClick }) 
                 onClose={handleClose}
             >
                 {items.map(item => (
-                    <MenuItem key={item.label}>
-                        <Button variant="text" color="primary" onClick={handleClick}>
+                    <MenuItem key={item.id} onClick={handleClose}>
+                        <Button variant="text" color="primary" onClick={item.handleClick}>
                             {i18n.t(item.label)}
                         </Button>
                     </MenuItem>

--- a/src/webapp/components/menu-button/MenuButton.tsx
+++ b/src/webapp/components/menu-button/MenuButton.tsx
@@ -2,6 +2,9 @@ import i18n from "@eyeseetea/feedback-component/locales";
 import Button from "@material-ui/core/Button";
 import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
+import KeyboardArrowDownIcon from "@material-ui/icons/KeyboardArrowDown";
+import KeyboardArrowUpIcon from "@material-ui/icons/KeyboardArrowUp";
+
 import { memo, useState, MouseEvent } from "react";
 import styled from "styled-components";
 
@@ -35,6 +38,7 @@ export const MenuButton: React.FC<Props> = memo(({ label, items }) => {
                 variant="contained"
                 color="primary"
                 onClick={onOpenMenu}
+                endIcon={anchorEl ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
             >
                 {i18n.t(label)}
             </Button>

--- a/src/webapp/components/menu-button/MenuButton.tsx
+++ b/src/webapp/components/menu-button/MenuButton.tsx
@@ -8,18 +8,18 @@ import KeyboardArrowUpIcon from "@material-ui/icons/KeyboardArrowUp";
 import { memo, useState, MouseEvent } from "react";
 import styled from "styled-components";
 
-type Item = {
+export type Item = {
     label: string;
     id: string;
-    handleClick: () => void;
 };
 
 type Props = {
     label: string;
     items: Item[];
+    onItemSelected: (id: string) => void;
 };
 
-export const MenuButton: React.FC<Props> = memo(({ label, items }) => {
+export const MenuButton: React.FC<Props> = memo(({ label, items, onItemSelected }) => {
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
     const onOpenMenu = (event: MouseEvent<HTMLButtonElement>) => {
@@ -28,6 +28,10 @@ export const MenuButton: React.FC<Props> = memo(({ label, items }) => {
 
     const handleClose = () => {
         setAnchorEl(null);
+    };
+
+    const handleClick = (item: Item) => {
+        onItemSelected(item.id);
     };
 
     return (
@@ -51,7 +55,7 @@ export const MenuButton: React.FC<Props> = memo(({ label, items }) => {
             >
                 {items.map(item => (
                     <MenuItem key={item.id} onClick={handleClose}>
-                        <Button variant="text" color="primary" onClick={item.handleClick}>
+                        <Button variant="text" color="primary" onClick={() => handleClick(item)}>
                             {i18n.t(item.label)}
                         </Button>
                     </MenuItem>

--- a/src/webapp/components/menu-button/MenuButton.tsx
+++ b/src/webapp/components/menu-button/MenuButton.tsx
@@ -1,0 +1,54 @@
+import i18n from "@eyeseetea/feedback-component/locales";
+import Button from "@material-ui/core/Button";
+import Menu from "@material-ui/core/Menu";
+import MenuItem from "@material-ui/core/MenuItem";
+import { memo, useState, MouseEvent } from "react";
+
+type Item = {
+    label: string;
+    value: string;
+};
+
+type Props = {
+    label: string;
+    items: Item[];
+};
+
+export const MenuButton: React.FC<Props> = memo(({ label, items }) => {
+    const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+    const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const handleClose = () => {
+        setAnchorEl(null);
+    };
+
+    return (
+        <>
+            <Button
+                aria-controls="simple-menu"
+                aria-haspopup="true"
+                variant="contained"
+                color="primary"
+                onClick={handleClick}
+            >
+                {i18n.t(label)}
+            </Button>
+            <Menu
+                id="simple-menu"
+                anchorEl={anchorEl}
+                keepMounted
+                open={Boolean(anchorEl)}
+                onClose={handleClose}
+            >
+                {items.map(item => (
+                    <MenuItem key={item.label} onClick={handleClose}>
+                        {i18n.t(item.label)}
+                    </MenuItem>
+                ))}
+            </Menu>
+        </>
+    );
+});

--- a/src/webapp/components/menu-button/MenuButton.tsx
+++ b/src/webapp/components/menu-button/MenuButton.tsx
@@ -1,4 +1,3 @@
-import i18n from "@eyeseetea/feedback-component/locales";
 import Button from "@material-ui/core/Button";
 import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
@@ -44,7 +43,7 @@ export const MenuButton: React.FC<Props> = memo(({ label, items, onItemSelected 
                 onClick={onOpenMenu}
                 endIcon={anchorEl ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
             >
-                {i18n.t(label)}
+                {label}
             </Button>
             <Menu
                 id="simple-menu"
@@ -56,7 +55,7 @@ export const MenuButton: React.FC<Props> = memo(({ label, items, onItemSelected 
                 {items.map(item => (
                     <MenuItem key={item.id} onClick={handleClose}>
                         <Button variant="text" color="primary" onClick={() => handleClick(item)}>
-                            {i18n.t(item.label)}
+                            {item.label}
                         </Button>
                     </MenuItem>
                 ))}

--- a/src/webapp/components/menu-button/MenuButton.tsx
+++ b/src/webapp/components/menu-button/MenuButton.tsx
@@ -3,21 +3,23 @@ import Button from "@material-ui/core/Button";
 import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
 import { memo, useState, MouseEvent } from "react";
+import styled from "styled-components";
 
 type Item = {
     label: string;
-    value: string;
+    id: string;
 };
 
 type Props = {
     label: string;
     items: Item[];
+    handleClick: () => void;
 };
 
-export const MenuButton: React.FC<Props> = memo(({ label, items }) => {
+export const MenuButton: React.FC<Props> = memo(({ label, items, handleClick }) => {
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
-    const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    const onOpenMenu = (event: MouseEvent<HTMLButtonElement>) => {
         setAnchorEl(event.currentTarget);
     };
 
@@ -26,13 +28,13 @@ export const MenuButton: React.FC<Props> = memo(({ label, items }) => {
     };
 
     return (
-        <>
+        <Container>
             <Button
                 aria-controls="simple-menu"
                 aria-haspopup="true"
                 variant="contained"
                 color="primary"
-                onClick={handleClick}
+                onClick={onOpenMenu}
             >
                 {i18n.t(label)}
             </Button>
@@ -44,11 +46,17 @@ export const MenuButton: React.FC<Props> = memo(({ label, items }) => {
                 onClose={handleClose}
             >
                 {items.map(item => (
-                    <MenuItem key={item.label} onClick={handleClose}>
-                        {i18n.t(item.label)}
+                    <MenuItem key={item.label}>
+                        <Button variant="text" color="primary" onClick={handleClick}>
+                            {i18n.t(item.label)}
+                        </Button>
                     </MenuItem>
                 ))}
             </Menu>
-        </>
+        </Container>
     );
 });
+
+const Container = styled.div`
+    margin-inline-start: 1rem;
+`;

--- a/src/webapp/pages/dashboard/hooks/useDashboard.tsx
+++ b/src/webapp/pages/dashboard/hooks/useDashboard.tsx
@@ -45,10 +45,12 @@ export function useDashboard() {
         {
             label: "Module 1",
             id: "module-1",
+            handleClick: () => alert("Module 1"),
         },
         {
             label: "Module 2",
             id: "module-2",
+            handleClick: () => alert("Module 2"),
         },
     ];
 
@@ -82,11 +84,7 @@ export function useDashboard() {
                 value={"somevalue"}
                 label={i18n.t("Status")}
             />
-            <MenuButton
-                label={"New Data Quality"}
-                items={menuButtonItems}
-                handleClick={() => alert("click")}
-            />
+            <MenuButton label={"New Data Quality"} items={menuButtonItems} />
         </>
     );
 

--- a/src/webapp/pages/dashboard/hooks/useDashboard.tsx
+++ b/src/webapp/pages/dashboard/hooks/useDashboard.tsx
@@ -43,11 +43,11 @@ export function useDashboard() {
 
     const menuButtonItems = [
         {
-            label: "Module 1",
+            label: i18n.t("Module 1"),
             id: "module-1",
         },
         {
-            label: "Module 2",
+            label: i18n.t("Module 2"),
             id: "module-2",
         },
     ];
@@ -88,7 +88,7 @@ export function useDashboard() {
                 label={i18n.t("Status")}
             />
             <MenuButton
-                label={"New Data Quality"}
+                label={i18n.t("New Data Quality")}
                 items={menuButtonItems}
                 onItemSelected={onMenuItemSelected}
             />
@@ -98,13 +98,13 @@ export function useDashboard() {
     const onDelete = () => {
         alert("delete element");
         setIsDialogOpen(false);
-        success("Selected element deleted successfully");
+        success(i18n.t("Selected element deleted successfully"));
     };
 
     const onToggleStatus = () => {
         alert("status changed");
         setIsDialogOpen(false);
-        success("Status changed");
+        success(i18n.t("Status changed"));
     };
 
     const onStartingAnalysis = () => {};

--- a/src/webapp/pages/dashboard/hooks/useDashboard.tsx
+++ b/src/webapp/pages/dashboard/hooks/useDashboard.tsx
@@ -7,7 +7,7 @@ import AssignmentOutlinedIcon from "@material-ui/icons/AssignmentOutlined";
 import { useSnackbar } from "@eyeseetea/d2-ui-components";
 import i18n from "$/utils/i18n";
 import { useCallback } from "react";
-import { MenuButton } from "$/webapp/components/menu-button/MenuButton";
+import { Item, MenuButton } from "$/webapp/components/menu-button/MenuButton";
 
 export function useDashboard() {
     const [statusIsCompleted, setStatusIsCompleted] = useState(false);
@@ -45,14 +45,17 @@ export function useDashboard() {
         {
             label: "Module 1",
             id: "module-1",
-            handleClick: () => alert("Module 1"),
         },
         {
             label: "Module 2",
             id: "module-2",
-            handleClick: () => alert("Module 2"),
         },
     ];
+
+    const onMenuItemSelected = (id: Item["id"]) => {
+        const selectedItem = menuButtonItems.find(item => item.id === id);
+        alert(selectedItem?.label);
+    };
 
     const customFilters = (
         <>
@@ -84,7 +87,11 @@ export function useDashboard() {
                 value={"somevalue"}
                 label={i18n.t("Status")}
             />
-            <MenuButton label={"New Data Quality"} items={menuButtonItems} />
+            <MenuButton
+                label={"New Data Quality"}
+                items={menuButtonItems}
+                onItemSelected={onMenuItemSelected}
+            />
         </>
     );
 

--- a/src/webapp/pages/dashboard/hooks/useDashboard.tsx
+++ b/src/webapp/pages/dashboard/hooks/useDashboard.tsx
@@ -7,6 +7,7 @@ import AssignmentOutlinedIcon from "@material-ui/icons/AssignmentOutlined";
 import { useSnackbar } from "@eyeseetea/d2-ui-components";
 import i18n from "$/utils/i18n";
 import { useCallback } from "react";
+import { MenuButton } from "$/webapp/components/menu-button/MenuButton";
 
 export function useDashboard() {
     const [statusIsCompleted, setStatusIsCompleted] = useState(false);
@@ -40,6 +41,17 @@ export function useDashboard() {
         alert(newSearch);
     }, []);
 
+    const menuButtonItems = [
+        {
+            label: "Module 1",
+            id: "module-1",
+        },
+        {
+            label: "Module 2",
+            id: "module-2",
+        },
+    ];
+
     const customFilters = (
         <>
             <Dropdown
@@ -69,6 +81,11 @@ export function useDashboard() {
                 onChange={valueChange}
                 value={"somevalue"}
                 label={i18n.t("Status")}
+            />
+            <MenuButton
+                label={"New Data Quality"}
+                items={menuButtonItems}
+                handleClick={() => alert("click")}
             />
         </>
     );


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes: [Create contextual menu for New Data Quality button, that lets you select 'Module 1' or 'Module 2' (Datasets)](https://app.clickup.com/t/8693qa4cq)

### :memo: Implementation

Add component based on [Material context menu](https://v4.mui.com/components/menus/#context-menu) but including buttons inside, at set it into the filters area of the table component.

### :video_camera: Screenshots/Screen capture
<img width="964" alt="Captura de pantalla 2024-02-26 a las 19 38 33" src="https://github.com/EyeSeeTea/data-quality-dev/assets/55712984/e0e92d99-6ba3-4f80-8afd-48a0b290ac18">
<img width="456" alt="Captura de pantalla 2024-02-26 a las 19 38 39" src="https://github.com/EyeSeeTea/data-quality-dev/assets/55712984/abda327e-091c-4361-bcec-b4e888d1b7c7">


### :fire: Notes to the tester
Check it out at dashboard page