### PR TITLE
Feat: accessible colors

### DIFF
--- a/src/webapp/components/empty-state/EmptyState.tsx
+++ b/src/webapp/components/empty-state/EmptyState.tsx
@@ -24,9 +24,9 @@ const Container = styled.section<ContainerProps>`
     display: flex;
     align-items: center;
     justify-content: center;
-    background-color: ${customTheme.color.lighterGrey};
-    color: ${customTheme.color.grey};
-    border-color: ${customTheme.color.grey};
+    background-color: ${customTheme.color.lightGrey};
+    color: ${customTheme.color.dark};
+    border-color: ${customTheme.color.dark};
     border: 1px solid;
     border-radius: 4px;
     height: 28rem;
@@ -35,7 +35,7 @@ const Container = styled.section<ContainerProps>`
     ${({ $variant }) =>
         $variant === "success" &&
         css`
-            background-color: ${customTheme.color.lighterGreen};
+            background-color: ${customTheme.color.lightGreen};
             color: ${customTheme.color.green};
             border-color: ${customTheme.color.green};
         `};

--- a/src/webapp/components/progress-status/ProgressStatus.tsx
+++ b/src/webapp/components/progress-status/ProgressStatus.tsx
@@ -34,8 +34,8 @@ const Container = styled.li<ContainerProps>`
     ${({ $status }) =>
         $status === "success" &&
         css`
-            background-color: ${customTheme.color.green};
-            border-color: ${customTheme.color.green};
+            background-color: ${customTheme.color.lightGreen};
+            border-color: ${customTheme.color.lightGreen};
         `};
 
     ${({ $status }) =>

--- a/src/webapp/components/progress-status/ProgressStatus.tsx
+++ b/src/webapp/components/progress-status/ProgressStatus.tsx
@@ -34,19 +34,19 @@ const Container = styled.li<ContainerProps>`
     ${({ $status }) =>
         $status === "success" &&
         css`
-            background-color: ${customTheme.color.lightGreen};
-            border-color: ${customTheme.color.lightGreen};
+            background-color: ${customTheme.color.green};
+            border-color: ${customTheme.color.green};
         `};
 
     ${({ $status }) =>
         $status === "danger" &&
         css`
-            background-color: ${customTheme.color.red};
-            border-color: ${customTheme.color.red};
+            background-color: ${customTheme.color.lightRed};
+            border-color: ${customTheme.color.lightRed};
         `};
 `;
 
 const StyledTypography = styled(Typography)`
     font-size: 0.75rem;
-    color: ${customTheme.color.white};
+    color: ${customTheme.color.dark};
 `;

--- a/src/webapp/pages/app/themes/customTheme.ts
+++ b/src/webapp/pages/app/themes/customTheme.ts
@@ -1,14 +1,12 @@
 const customTheme = {
     color: {
-        white: "#ffffff",
-        black: "#111111",
-        grey: "#8e8e8e",
-        lightGrey: "#BDBDBD",
-        lighterGrey: "#F2F2F2",
-        green: "#355B37",
-        lightGreen: "#4CAF50",
-        lighterGreen: "#D8EDD9",
-        red: "#D32F2F",
+        light: "#ffffff",
+        dark: "#333333",
+        grey: "#717171",
+        lightGrey: "#D7D7D7",
+        green: "#163318",
+        lightGreen: "#B5DFB7",
+        lightRed: "#FFB8B8",
     },
 };
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes [DQ: Stepper checks for run steps not fully working + Change colors of OK/KO Steps in Main View](https://app.clickup.com/t/86942dpd2)
-  **#id for automatic link:** #CU-86942dpd2

### :memo: Implementation

Implement darker colors to meet W3C accessibility standards

<img width="474" alt="Captura de pantalla 2024-03-15 a las 12 35 59" src="https://github.com/EyeSeeTea/data-quality-dev/assets/55712984/03fcce48-1cbb-4263-88ae-f73ba6b82b72">


