### PR TITLE
Feat/dq improve current icons in the stepper

### DIFF
--- a/src/webapp/pages/analysis/AnalysisPage.tsx
+++ b/src/webapp/pages/analysis/AnalysisPage.tsx
@@ -36,7 +36,13 @@ const useStyles = makeStyles(() => ({
     inactive: {
         backgroundColor: "#8E8E8E",
     },
-    largeIcon: { fontSize: "32px" },
+    largeIcon: {
+        fontSize: "20px",
+        color: "#fff",
+        backgroundColor: "#1976d2",
+        borderRadius: 50,
+        padding: "0.125rem",
+    },
 }));
 
 function StepIcon(props: { completed: boolean; active: boolean; text: string }) {

--- a/src/webapp/pages/analysis/AnalysisPage.tsx
+++ b/src/webapp/pages/analysis/AnalysisPage.tsx
@@ -3,7 +3,7 @@ import { makeStyles } from "@material-ui/core";
 import { Wizard, WizardStep } from "@eyeseetea/d2-ui-components";
 import SettingsIcon from "@material-ui/icons/Settings";
 import ListAltIcon from "@material-ui/icons/ListAlt";
-import CheckCircleIcon from "@material-ui/icons/CheckCircle";
+import CheckIcon from "@material-ui/icons/Check";
 import customTheme from "$/webapp/pages/app/themes/customTheme";
 import { PageHeader } from "$/webapp/components/page-header/PageHeader";
 import { getComponentFromSectionName } from "./steps";
@@ -57,11 +57,11 @@ function StepIcon(props: {
     text: string;
     hasIssues: boolean;
 }) {
-    const { active, completed, text, hasIssues } = props;
+    const { active, text, hasIssues } = props;
     const classes = useStyles();
-    if (completed)
+    if (!hasIssues)
         return (
-            <CheckCircleIcon
+            <CheckIcon
                 className={classes.largeIcon}
                 htmlColor={`${customTheme.color.intenseGreen}`}
             />

--- a/src/webapp/pages/analysis/AnalysisPage.tsx
+++ b/src/webapp/pages/analysis/AnalysisPage.tsx
@@ -4,7 +4,7 @@ import { Wizard, WizardStep } from "@eyeseetea/d2-ui-components";
 import SettingsIcon from "@material-ui/icons/Settings";
 import ListAltIcon from "@material-ui/icons/ListAlt";
 import CheckCircleIcon from "@material-ui/icons/CheckCircle";
-
+import customTheme from "$/webapp/pages/app/themes/customTheme";
 import { PageHeader } from "$/webapp/components/page-header/PageHeader";
 import { getComponentFromSectionName } from "./steps";
 import styled from "styled-components";
@@ -36,6 +36,12 @@ const useStyles = makeStyles(() => ({
     inactive: {
         backgroundColor: "#8E8E8E",
     },
+    completed: {
+        backgroundColor: customTheme.color.intenseGreen,
+    },
+    withIssues: {
+        backgroundColor: customTheme.color.error,
+    },
     largeIcon: {
         fontSize: "20px",
         color: "#fff",
@@ -45,10 +51,25 @@ const useStyles = makeStyles(() => ({
     },
 }));
 
-function StepIcon(props: { completed: boolean; active: boolean; text: string }) {
-    const { active, completed, text } = props;
+function StepIcon(props: {
+    completed: boolean;
+    active: boolean;
+    text: string;
+    hasIssues: boolean;
+}) {
+    const { active, completed, text, hasIssues } = props;
     const classes = useStyles();
-    if (completed) return <CheckCircleIcon className={classes.largeIcon} htmlColor="#B5DFB7" />;
+    if (completed)
+        return (
+            <CheckCircleIcon
+                className={classes.largeIcon}
+                htmlColor={`${customTheme.color.intenseGreen}`}
+            />
+        );
+
+    const issueClasses = _([classes.circle, classes.withIssues]).compact().join(" ");
+
+    if (hasIssues) return <div className={issueClasses}>{text}</div>;
 
     const mergeClasses = _([classes.circle, active ? classes.active : classes.inactive])
         .compact()
@@ -71,10 +92,18 @@ function buildStepsFromSections(
             const index = analysis.sections.findIndex(s => s.id === section.id) + 1;
             const isActive = currentSection === section.name;
             const isCompleted = !QualityAnalysisSection.isPending(section);
+            const hasIssues = section.issues.length > 0;
 
             return {
                 id: section.id,
-                icon: <StepIcon active={isActive} completed={isCompleted} text={String(index)} />,
+                icon: (
+                    <StepIcon
+                        active={isActive}
+                        completed={isCompleted}
+                        text={String(index)}
+                        hasIssues={hasIssues}
+                    />
+                ),
                 key: section.name.toLowerCase(),
                 label: section.name,
                 component: () => (

--- a/src/webapp/pages/app/themes/customTheme.ts
+++ b/src/webapp/pages/app/themes/customTheme.ts
@@ -12,6 +12,7 @@ const customTheme = {
         lightRed: "#FFB8B8",
         lightWarning: "#FFF4E5",
         warning: "#663C00",
+        error: "#B80000",
     },
 };
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes [DQ: Improve current icons in the Stepper](https://app.clickup.com/t/86947x6dc)
- CU-86947x6dc

### :memo: Implementation

The color scheme is supposed to work like this:
- The step is either pending of analysis or active --> grey background
- The step has unresolved issues --> red background
- The step has no issues --> green background

As client is about to check the app, I left some classes there just in case there is need of changing the color scheme. 

### :video_camera: Screenshots/Screen capture
<img width="920" alt="Captura de pantalla 2024-04-09 a las 14 14 12" src="https://github.com/EyeSeeTea/data-quality-dev/assets/55712984/e67070c4-c2b4-46ca-83dc-497df6d60d55">


### :fire: Notes to the tester
