### PR TITLE
get url from d2Api instead env. variable

### DIFF
--- a/src/webapp/pages/app/Dhis2App.tsx
+++ b/src/webapp/pages/app/Dhis2App.tsx
@@ -65,7 +65,7 @@ async function getData(): Promise<CompositionRootResult> {
 
         const userSettings = await api.get<{ keyUiLocale: string }>("/userSettings").getData();
         configI18n(userSettings);
-        await setupLogger("http://localhost:8080", metadata.programs.qualityIssues.id);
+        await setupLogger(api.baseUrl, metadata.programs.qualityIssues.id);
         return { type: "loaded", data: { baseUrl, compositionRoot, metadata: metadata, api: api } };
     } catch (err) {
         return { type: "error", error: { baseUrl, error: err as Error } };


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #?

### :memo: Implementation

Since we don't have any env. variable for the API url in the `build` process i'm using `baseUrl` from d2Api to setup d2-logger.

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester

- Build the app

```bash
yarn build
```

- Install in app management.

- Should work in any server without further configuration.
