### PR TITLE
fixed period range for datavalues endpoint

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-10-30T13:32:55.750Z\n"
-"PO-Revision-Date: 2024-10-30T13:32:55.750Z\n"
+"POT-Creation-Date: 2024-11-04T15:12:23.322Z\n"
+"PO-Revision-Date: 2024-11-04T15:12:23.322Z\n"
 
 msgid "ID"
 msgstr ""
@@ -200,6 +200,9 @@ msgid "Configuration"
 msgstr ""
 
 msgid "Summary"
+msgstr ""
+
+msgid "You must save the Analysis configuration before running any step"
 msgstr ""
 
 msgid "Algorithm"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-05-16T07:04:50.457Z\n"
-"PO-Revision-Date: 2024-05-16T07:04:50.458Z\n"
+"POT-Creation-Date: 2024-10-30T13:32:55.750Z\n"
+"PO-Revision-Date: 2024-10-30T13:32:55.750Z\n"
 
 msgid "ID"
 msgstr ""
@@ -54,6 +54,9 @@ msgid "Yes"
 msgstr ""
 
 msgid "No"
+msgstr ""
+
+msgid "Select at least one organisation unit"
 msgstr ""
 
 msgid "Cannot be blank: {{fieldName}}"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2024-05-16T07:04:50.457Z\n"
+"POT-Creation-Date: 2024-10-30T13:32:55.750Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -54,6 +54,9 @@ msgid "Yes"
 msgstr ""
 
 msgid "No"
+msgstr ""
+
+msgid "Select at least one organisation unit"
 msgstr ""
 
 msgid "Cannot be blank: {{fieldName}}"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2024-10-30T13:32:55.750Z\n"
+"POT-Creation-Date: 2024-11-04T15:12:23.322Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -200,6 +200,9 @@ msgid "Configuration"
 msgstr ""
 
 msgid "Summary"
+msgstr ""
+
+msgid "You must save the Analysis configuration before running any step"
 msgstr ""
 
 msgid "Algorithm"

--- a/src/CompositionRoot.ts
+++ b/src/CompositionRoot.ts
@@ -88,7 +88,9 @@ type Repositories = {
 
 function getCompositionRoot(repositories: Repositories, metadata: MetadataItem) {
     return {
-        countries: { getByIds: new GetCountriesByIdsUseCase(repositories.countryRepository) },
+        countries: {
+            getByIds: new GetCountriesByIdsUseCase(repositories.countryRepository, metadata),
+        },
         users: { getCurrent: new GetCurrentUserUseCase(repositories.usersRepository) },
         modules: {
             get: new GetModulesUseCase(repositories.moduleRepository),

--- a/src/data/repositories/ValidationRuleAnalysisD2Repository.ts
+++ b/src/data/repositories/ValidationRuleAnalysisD2Repository.ts
@@ -9,11 +9,14 @@ import {
 import { ValidationRule } from "$/domain/entities/ValidationRuleGroup";
 import _ from "$/domain/entities/generic/Collection";
 import { Future } from "$/domain/entities/generic/Future";
+import i18n from "$/utils/i18n";
 
 export class ValidationRuleAnalysisD2Repository implements ValidationRuleAnalysisRepository {
     constructor(private api: D2Api) {}
 
     get(options: ValidationRuleOptions): FutureData<ValidationRuleAnalysis[]> {
+        if (!options.countryId)
+            return Future.error(new Error(i18n.t("Select at least one organisation unit")));
         return apiToFuture(
             this.api.request<D2ValidationRuleAnalysis[]>({
                 method: "post",

--- a/src/domain/entities/QualityAnalysis.ts
+++ b/src/domain/entities/QualityAnalysis.ts
@@ -42,7 +42,10 @@ export class QualityAnalysis extends Struct<QualityAnalysisAttrs>() {
             ? [
                   {
                       property: "countriesAnalysis" as const,
-                      errors: validateRequired(qualityAnalysis.countriesAnalysis),
+                      errors: validateRequired(
+                          qualityAnalysis.countriesAnalysis,
+                          "country_validation"
+                      ),
                       value: qualityAnalysis.countriesAnalysis,
                   },
               ]

--- a/src/domain/entities/Settings.ts
+++ b/src/domain/entities/Settings.ts
@@ -48,11 +48,6 @@ export class Settings extends Struct<SettingsAttrs>() {
                 errors: validateRequired(settings.startDate),
                 value: settings.startDate,
             },
-            {
-                property: "countryIds" as const,
-                errors: validateRequired(settings.countryIds),
-                value: settings.countryIds,
-            },
         ].filter(validation => validation.errors.length > 0);
 
         if (errors.length === 0) {

--- a/src/domain/entities/generic/Errors.ts
+++ b/src/domain/entities/generic/Errors.ts
@@ -1,8 +1,9 @@
 import i18n from "$/utils/i18n";
 
-export type ValidationErrorKey = "field_cannot_be_blank";
+export type ValidationErrorKey = "field_cannot_be_blank" | "country_validation";
 
 export const validationErrorMessages: Record<ValidationErrorKey, (fieldName: string) => string> = {
+    country_validation: () => i18n.t("Select at least one organisation unit"),
     field_cannot_be_blank: (fieldName: string) =>
         i18n.t(`Cannot be blank: {{fieldName}}`, { fieldName: fieldName, nsSeparator: false }),
 };

--- a/src/domain/entities/generic/validations.ts
+++ b/src/domain/entities/generic/validations.ts
@@ -1,7 +1,14 @@
 import { ValidationErrorKey } from "./Errors";
 
-export function validateRequired(value: any): ValidationErrorKey[] {
+export function validateRequired(
+    value: any,
+    errorCode: ValidationErrorKey = "field_cannot_be_blank"
+): ValidationErrorKey[] {
     const isBlank = !value || (value.length !== undefined && value.length === 0);
 
-    return isBlank ? ["field_cannot_be_blank"] : [];
+    return isBlank ? setErrorCode(errorCode) : [];
+}
+
+function setErrorCode(errorCode?: ValidationErrorKey): ValidationErrorKey[] {
+    return errorCode ? [errorCode] : ["field_cannot_be_blank"];
 }

--- a/src/domain/usecases/CreateQualityAnalysisUseCase.ts
+++ b/src/domain/usecases/CreateQualityAnalysisUseCase.ts
@@ -49,9 +49,7 @@ export class CreateQualityAnalysisUseCase {
                 status: "In Progress",
                 lastModification: "",
                 countriesAnalysis: defaultSettings.countryIds,
-                sequential: {
-                    value: `DQ-${sequential.value}`,
-                },
+                sequential: { value: `DQ-${sequential.value}` },
             }).match({
                 error: errors => {
                     const errorMessages = getErrors(errors);

--- a/src/domain/usecases/GetCountriesByIdsUseCase.ts
+++ b/src/domain/usecases/GetCountriesByIdsUseCase.ts
@@ -1,14 +1,21 @@
 import { FutureData } from "$/data/api-futures";
 import { Country } from "$/domain/entities/Country";
+import { MetadataItem } from "$/domain/entities/MetadataItem";
 import { Id } from "$/domain/entities/Ref";
 import { Future } from "$/domain/entities/generic/Future";
 import { CountryRepository } from "$/domain/repositories/CountryRepository";
 
 export class GetCountriesByIdsUseCase {
-    constructor(private countryRepository: CountryRepository) {}
+    constructor(private countryRepository: CountryRepository, private config: MetadataItem) {}
 
     execute(ids: Id[]): FutureData<Country[]> {
         if (ids.length === 0) return Future.success([]);
-        return this.countryRepository.getByIds(ids);
+
+        return this.countryRepository.getByIds(ids).map(countries => {
+            const excludeGlobal = countries.filter(
+                country => country.id !== this.config.organisationUnits.global.id
+            );
+            return excludeGlobal;
+        });
     }
 }

--- a/src/domain/usecases/GetCountriesByIdsUseCase.ts
+++ b/src/domain/usecases/GetCountriesByIdsUseCase.ts
@@ -11,11 +11,6 @@ export class GetCountriesByIdsUseCase {
     execute(ids: Id[]): FutureData<Country[]> {
         if (ids.length === 0) return Future.success([]);
 
-        return this.countryRepository.getByIds(ids).map(countries => {
-            const excludeGlobal = countries.filter(
-                country => country.id !== this.config.organisationUnits.global.id
-            );
-            return excludeGlobal;
-        });
+        return this.countryRepository.getByIds(ids);
     }
 }

--- a/src/domain/usecases/RunValidationsUseCase.ts
+++ b/src/domain/usecases/RunValidationsUseCase.ts
@@ -14,6 +14,7 @@ import { ValidationRuleGroupRepository } from "$/domain/repositories/ValidationR
 import { ValidationRuleGroup } from "$/domain/entities/ValidationRuleGroup";
 import { MetadataItem } from "$/domain/entities/MetadataItem";
 import { CountryRepository } from "$/domain/repositories/CountryRepository";
+import i18n from "$/utils/i18n";
 
 export class RunValidationsUseCase {
     private issueUseCase: UCIssue;
@@ -39,6 +40,8 @@ export class RunValidationsUseCase {
                 options.validationRuleGroupId
             ),
         }).flatMap(({ analysis, validationRuleGroup }) => {
+            if (analysis.countriesAnalysis.length === 0)
+                return Future.error(new Error(i18n.t("Select at least one organisation unit")));
             const checkAllCountries = this.isGlobalInCountries(analysis.countriesAnalysis);
             return this.getAllCountries(checkAllCountries, analysis).flatMap(countriesIds => {
                 return this.getValidationRuleAnalysis(analysis, countriesIds, options).flatMap(

--- a/src/domain/usecases/common/UCDataValue.ts
+++ b/src/domain/usecases/common/UCDataValue.ts
@@ -10,13 +10,16 @@ export class UCDataValue {
     constructor(private dataValueRepository: DataValueRepository) {}
 
     get(countriesIds: Id[], moduleIds: Id[], periods: Period[]): FutureData<DataValue[]> {
+        const [startDate, endDate] = periods;
+        if (!startDate || !endDate) throw new Error("Invalid period");
+        const periodsToSearch = _.range(Number(startDate), Number(endDate) + 1);
         const $requests = _(countriesIds)
             .chunk(1)
             .map(countryIds => {
                 return this.dataValueRepository.get({
                     moduleIds: moduleIds,
                     countriesIds: countryIds,
-                    period: _(periods).uniq().value(),
+                    period: periodsToSearch.map(period => String(period)),
                 });
             })
             .value();

--- a/src/domain/usecases/common/UCDataValue.ts
+++ b/src/domain/usecases/common/UCDataValue.ts
@@ -5,11 +5,15 @@ import { DataValue } from "$/domain/entities/DataValue";
 import { Id, Period } from "$/domain/entities/Ref";
 import { DataValueRepository } from "$/domain/repositories/DataValueRepository";
 import { Future } from "$/domain/entities/generic/Future";
+import i18n from "$/utils/i18n";
 
 export class UCDataValue {
     constructor(private dataValueRepository: DataValueRepository) {}
 
     get(countriesIds: Id[], moduleIds: Id[], periods: Period[]): FutureData<DataValue[]> {
+        if (countriesIds.length === 0)
+            throw new Error(i18n.t("Select at least one organisation unit"));
+
         const [startDate, endDate] = periods;
         if (!startDate || !endDate) throw new Error("Invalid period");
         const periodsToSearch = _.range(Number(startDate), Number(endDate) + 1);

--- a/src/webapp/components/configuration-form/ConfigurationForm.tsx
+++ b/src/webapp/components/configuration-form/ConfigurationForm.tsx
@@ -154,7 +154,7 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = React.memo(pr
                     onChange={onOrgUnitsChange}
                     selected={selectedOrgUnits}
                     levels={[1, 2, 3]}
-                    selectableLevels={[1, 2, 3]}
+                    selectableLevels={[2, 3]}
                     rootIds={currentUser.countries.map(country => country.id)}
                     withElevation={false}
                 />

--- a/src/webapp/components/configuration-form/ConfigurationForm.tsx
+++ b/src/webapp/components/configuration-form/ConfigurationForm.tsx
@@ -12,6 +12,7 @@ import _ from "$/domain/entities/generic/Collection";
 import { Country } from "$/domain/entities/Country";
 import styled from "styled-components";
 import { getDefaultModules } from "$/data/common/D2Module";
+import { Alert } from "@material-ui/lab";
 
 export function getIdFromCountriesPaths(paths: string[]): string[] {
     return _(paths)
@@ -60,11 +61,7 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = React.memo(pr
     }, [countries]);
 
     const modules = getDefaultModules(metadata);
-
-    const moduleItems = modules.map(module => ({
-        value: module.id,
-        text: module.name,
-    }));
+    const moduleItems = modules.map(module => ({ value: module.id, text: module.name }));
 
     const onFormSubmit = React.useCallback(
         (e: React.FormEvent<HTMLFormElement>) => {
@@ -111,6 +108,14 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = React.memo(pr
 
     return (
         <Form onSubmit={onFormSubmit}>
+            {selectedOrgUnits.length === 0 && (
+                <AlertContainer>
+                    <Alert severity="error">
+                        {i18n.t("Select at least one organisation unit")}
+                    </Alert>
+                </AlertContainer>
+            )}
+
             <FormControlsContainer>
                 <StyledTextField
                     inputRef={inputRef}
@@ -205,4 +210,8 @@ const OrgUnitContainer = styled.div<{ $disabled?: boolean }>`
 
 const ActionsContainer = styled.div`
     text-align: right;
+`;
+
+const AlertContainer = styled.div`
+    margin-block: 1em;
 `;

--- a/src/webapp/components/configuration-form/ConfigurationForm.tsx
+++ b/src/webapp/components/configuration-form/ConfigurationForm.tsx
@@ -45,7 +45,7 @@ export function useCountries(props: UseCountriesProps) {
 }
 
 export const ConfigurationForm: React.FC<ConfigurationFormProps> = React.memo(props => {
-    const { initialData, onSave } = props;
+    const { initialData, onSave, updateCountry } = props;
     const { api, currentUser, metadata } = useAppContext();
     const { countries } = useCountries({ ids: initialData.countriesAnalysis });
     const [formData, setFormData] = React.useState<QualityAnalysis>(() => {
@@ -101,6 +101,7 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = React.memo(pr
 
     const onOrgUnitsChange = (value: Id[]) => {
         setSelectedOrgUnits(value);
+        updateCountry(value.length > 0);
     };
 
     const disableSave = QualityAnalysis.hasExecutedSections(formData);
@@ -177,6 +178,7 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = React.memo(pr
 type ConfigurationFormProps = {
     initialData: QualityAnalysis;
     onSave: (data: QualityAnalysis) => void;
+    updateCountry: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 type UseCountriesProps = { ids: Id[] };

--- a/src/webapp/pages/analysis/AnalysisPage.tsx
+++ b/src/webapp/pages/analysis/AnalysisPage.tsx
@@ -78,9 +78,7 @@ function StepIcon(props: {
 function buildStepsFromSections(
     analysis: QualityAnalysis,
     updateAnalysis: UpdateAnalysisState,
-    currentSection: Maybe<string>,
     classes: ClassNameMap<"circle" | "pending" | "completed" | "error" | "largeIcon">,
-
     qualityFilters: { algorithm: string; threshold: string },
     onQualityFilterChange: (value: Maybe<string>, filterAttribute: string) => void
 ): WizardStep[] {
@@ -123,7 +121,7 @@ function buildStepsFromSections(
 
     return [
         {
-            key: "Configuration",
+            key: "configuration",
             label: i18n.t("Configuration"),
             component: () => (
                 <ConfigurationStep updateAnalysis={updateAnalysis} analysis={analysis} />
@@ -179,12 +177,11 @@ export const AnalysisPage: React.FC<PageProps> = React.memo(() => {
         return buildStepsFromSections(
             analysis,
             setAnalysis,
-            currentSection,
             classes,
             qualityFilters,
             onFilterChange
         );
-    }, [analysis, setAnalysis, currentSection, classes, onFilterChange, qualityFilters]);
+    }, [analysis, setAnalysis, classes, onFilterChange, qualityFilters]);
 
     const onStepChange = React.useCallback(
         (value: string) => {
@@ -208,7 +205,7 @@ export const AnalysisPage: React.FC<PageProps> = React.memo(() => {
             <PageHeader title={`${analysis.name} - ${currentSection}`} onBackClick={onBack} />
             <Stepper
                 lastClickableStepIndex={analysisSteps.length}
-                initialStepKey={firstSectionName}
+                initialStepKey="configuration"
                 steps={analysisSteps}
                 onStepChange={onStepChange}
             />

--- a/src/webapp/pages/analysis/AnalysisPage.tsx
+++ b/src/webapp/pages/analysis/AnalysisPage.tsx
@@ -19,6 +19,7 @@ import _ from "$/domain/entities/generic/Collection";
 import { QualityAnalysisSection } from "$/domain/entities/QualityAnalysisSection";
 import { Maybe } from "$/utils/ts-utils";
 import { SummaryStep } from "./SummaryStep";
+import { getErrors } from "$/domain/entities/generic/Errors";
 
 const defaultOutlierParams = { algorithm: "Z_SCORE", threshold: "3" };
 
@@ -80,7 +81,8 @@ function buildStepsFromSections(
     updateAnalysis: UpdateAnalysisState,
     classes: ClassNameMap<"circle" | "pending" | "completed" | "error" | "largeIcon">,
     qualityFilters: { algorithm: string; threshold: string },
-    onQualityFilterChange: (value: Maybe<string>, filterAttribute: string) => void
+    onQualityFilterChange: (value: Maybe<string>, filterAttribute: string) => void,
+    setCountrySelected: React.Dispatch<React.SetStateAction<boolean>>
 ): WizardStep[] {
     const sectionSteps = _(analysis.sections)
         .map((section): Maybe<WizardStep & { id: string }> => {
@@ -104,6 +106,7 @@ function buildStepsFromSections(
                 ),
                 key: section.name.toLowerCase(),
                 label: section.name,
+                props: { analysis: analysis },
                 component: () => (
                     <StepComponent
                         analysis={analysis}
@@ -123,8 +126,13 @@ function buildStepsFromSections(
         {
             key: "configuration",
             label: i18n.t("Configuration"),
+            props: { analysis },
             component: () => (
-                <ConfigurationStep updateAnalysis={updateAnalysis} analysis={analysis} />
+                <ConfigurationStep
+                    updateCountry={setCountrySelected}
+                    updateAnalysis={updateAnalysis}
+                    analysis={analysis}
+                />
             ),
             completed: false,
             icon: <SettingsIcon className={classes.largeIcon} />,
@@ -133,6 +141,7 @@ function buildStepsFromSections(
         {
             icon: <ListAltIcon className={classes.largeIcon} />,
             key: "Summary",
+            props: { analysis },
             label: i18n.t("Summary"),
             component: () => <SummaryStep analysis={analysis} name={i18n.t("Summary")} />,
             completed: false,
@@ -162,6 +171,7 @@ export const AnalysisPage: React.FC<PageProps> = React.memo(() => {
     };
 
     const { analysis, setAnalysis, isLoading, error } = useAnalysisById(id);
+    const [countrySelected, setCountrySelected] = React.useState(false);
 
     useEffect(() => {
         if (isLoading) loading.show();
@@ -179,9 +189,10 @@ export const AnalysisPage: React.FC<PageProps> = React.memo(() => {
             setAnalysis,
             classes,
             qualityFilters,
-            onFilterChange
+            onFilterChange,
+            setCountrySelected
         );
-    }, [analysis, setAnalysis, classes, onFilterChange, qualityFilters]);
+    }, [analysis, setAnalysis, classes, onFilterChange, qualityFilters, setCountrySelected]);
 
     const onStepChange = React.useCallback(
         (value: string) => {
@@ -190,6 +201,25 @@ export const AnalysisPage: React.FC<PageProps> = React.memo(() => {
             setSection(section?.name || value);
         },
         [analysis]
+    );
+
+    const validateAnalysis = React.useCallback(
+        async (currentStep: WizardStep) => {
+            if (!currentStep.props) return Promise.resolve([]);
+            const currentAnalysis = currentStep.props as { analysis: QualityAnalysis };
+            return QualityAnalysis.updateConfiguration(currentAnalysis.analysis).match({
+                success: () => {
+                    return Promise.resolve([]);
+                },
+                error: errors => {
+                    const errorMessage = countrySelected
+                        ? i18n.t("You must save the Analysis configuration before running any step")
+                        : getErrors(errors);
+                    return Promise.resolve([errorMessage]);
+                },
+            });
+        },
+        [countrySelected]
     );
 
     if (!analysis) return null;
@@ -208,6 +238,8 @@ export const AnalysisPage: React.FC<PageProps> = React.memo(() => {
                 initialStepKey="configuration"
                 steps={analysisSteps}
                 onStepChange={onStepChange}
+                onStepChangeRequest={validateAnalysis}
+                useSnackFeedback
             />
         </PageContainer>
     );

--- a/src/webapp/pages/analysis/steps/ConfigurationStep.tsx
+++ b/src/webapp/pages/analysis/steps/ConfigurationStep.tsx
@@ -11,12 +11,13 @@ import { UpdateAnalysisState } from "$/webapp/pages/analysis/AnalysisPage";
 export type ConfigurationStepProps = {
     analysis: QualityAnalysis;
     updateAnalysis: UpdateAnalysisState;
+    updateCountry: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 const noop = () => {};
 
 export const ConfigurationStep: React.FC<ConfigurationStepProps> = React.memo(props => {
-    const { analysis, updateAnalysis } = props;
+    const { analysis, updateAnalysis, updateCountry } = props;
     const { saveQualityAnalysis } = useAnalysisMethods({
         onSuccess: noop,
         onRemove: noop,
@@ -37,7 +38,11 @@ export const ConfigurationStep: React.FC<ConfigurationStepProps> = React.memo(pr
             <TitleContainer>
                 <StyledTypography variant="h2">{i18n.t("Configuration")}</StyledTypography>
             </TitleContainer>
-            <ConfigurationForm initialData={analysis} onSave={onSave} />
+            <ConfigurationForm
+                updateCountry={updateCountry}
+                initialData={analysis}
+                onSave={onSave}
+            />
         </Container>
     );
 });


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8696c24p6

### :memo: Implementation

- [x] change startDate/endDate parameter and use the period parameter to send all the selected periods
- [x] create analysis without default org. unit (set default org. units in dataStore: data-quality/settings)

### :video_camera: Screenshots/Screen capture

![image](https://github.com/user-attachments/assets/481d0c6a-f290-4dfa-ad03-eba004bdb17f)

![image](https://github.com/user-attachments/assets/fdbbb911-f6b5-4d95-9dd8-e8dd4c9350c5)

![image](https://github.com/user-attachments/assets/02470368-03bc-45da-9859-b3ea84f44787)

**Create analysis without org. unit**

[Data-Quality_no_default_org_unit.webm](https://github.com/user-attachments/assets/76beed56-a48c-4250-9ece-29e624c869cd)


### :fire: Notes to the tester

Running an analysis within max range in years (2020-2023) and the global org. unit could take a lot of time (10 minutes in my local environment)

#8696c24p6