### PR TITLE
add tracker compatibility for version 41

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-05-16T07:04:50.457Z\n"
-"PO-Revision-Date: 2024-05-16T07:04:50.458Z\n"
+"POT-Creation-Date: 2024-11-04T15:12:23.322Z\n"
+"PO-Revision-Date: 2024-11-04T15:12:23.322Z\n"
 
 msgid "ID"
 msgstr ""
@@ -54,6 +54,9 @@ msgid "Yes"
 msgstr ""
 
 msgid "No"
+msgstr ""
+
+msgid "Select at least one organisation unit"
 msgstr ""
 
 msgid "Cannot be blank: {{fieldName}}"
@@ -197,6 +200,9 @@ msgid "Configuration"
 msgstr ""
 
 msgid "Summary"
+msgstr ""
+
+msgid "You must save the Analysis configuration before running any step"
 msgstr ""
 
 msgid "Algorithm"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2024-05-16T07:04:50.457Z\n"
+"POT-Creation-Date: 2024-11-04T15:12:23.322Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -54,6 +54,9 @@ msgid "Yes"
 msgstr ""
 
 msgid "No"
+msgstr ""
+
+msgid "Select at least one organisation unit"
 msgstr ""
 
 msgid "Cannot be blank: {{fieldName}}"
@@ -197,6 +200,9 @@ msgid "Configuration"
 msgstr ""
 
 msgid "Summary"
+msgstr ""
+
+msgid "You must save the Analysis configuration before running any step"
 msgstr ""
 
 msgid "Algorithm"

--- a/src/CompositionRoot.ts
+++ b/src/CompositionRoot.ts
@@ -88,7 +88,9 @@ type Repositories = {
 
 function getCompositionRoot(repositories: Repositories, metadata: MetadataItem) {
     return {
-        countries: { getByIds: new GetCountriesByIdsUseCase(repositories.countryRepository) },
+        countries: {
+            getByIds: new GetCountriesByIdsUseCase(repositories.countryRepository, metadata),
+        },
         users: { getCurrent: new GetCurrentUserUseCase(repositories.usersRepository) },
         modules: {
             get: new GetModulesUseCase(repositories.moduleRepository),

--- a/src/data/common/utils.ts
+++ b/src/data/common/utils.ts
@@ -1,5 +1,7 @@
 import { MetadataItem } from "$/domain/entities/MetadataItem";
 import { Id } from "$/domain/entities/Ref";
+import { TrackedEntitiesGetResponse } from "$/types/d2-api";
+import { TrackerEventsResponse } from "@eyeseetea/d2-api/api/trackerEvents";
 
 export function getProgramStageIndexById(programStageId: Id, metadata: MetadataItem): number {
     const programStageIndex = metadata.programs.qualityIssues.programStages.findIndex(
@@ -7,4 +9,32 @@ export function getProgramStageIndexById(programStageId: Id, metadata: MetadataI
     );
     if (programStageIndex === -1) throw Error(`Cannot found programStage: ${programStageId}`);
     return programStageIndex;
+}
+
+export function buildTrackerResponse(
+    response: TrackedEntitiesGetResponse & {
+        trackedEntities?: TrackedEntitiesGetResponse["instances"];
+    }
+): TrackedEntitiesGetResponse {
+    if (!response.instances && response.trackedEntities) {
+        return { ...response, instances: response.trackedEntities };
+    } else if (!response.trackedEntities && response.instances) {
+        return response;
+    } else {
+        return response;
+    }
+}
+
+export function buildTrackerEventsResponse(
+    response: TrackerEventsResponse & {
+        events?: TrackerEventsResponse["instances"];
+    }
+): TrackerEventsResponse {
+    if (!response.instances && response.events) {
+        return { ...response, instances: response.events };
+    } else if (!response.events && response.instances) {
+        return response;
+    } else {
+        return response;
+    }
 }

--- a/src/data/repositories/IssueD2Repository.ts
+++ b/src/data/repositories/IssueD2Repository.ts
@@ -21,7 +21,11 @@ import { Maybe } from "$/utils/ts-utils";
 import { IssueAction } from "$/domain/entities/IssueAction";
 import { IssueStatus } from "$/domain/entities/IssueStatus";
 import { getDefaultModules } from "$/data/common/D2Module";
-import { getProgramStageIndexById } from "$/data/common/utils";
+import {
+    buildTrackerEventsResponse,
+    buildTrackerResponse,
+    getProgramStageIndexById,
+} from "$/data/common/utils";
 
 export class IssueD2Repository implements IssueRepository {
     d2DataElement: D2DataElement;
@@ -61,7 +65,7 @@ export class IssueD2Repository implements IssueRepository {
                 event: filters.id ? filters.id : undefined,
             })
         ).flatMap(d2Response => {
-            const instances = d2Response.instances;
+            const instances = buildTrackerEventsResponse(d2Response).instances;
             const orgUnitIds = this.getRelatedIdsFromDataValues(
                 instances,
                 this.getDataElementIdOrThrow("country")
@@ -100,7 +104,7 @@ export class IssueD2Repository implements IssueRepository {
                 event: id ? id : undefined,
             })
         ).flatMap(d2Response => {
-            const d2Event = d2Response.instances[0];
+            const d2Event = buildTrackerEventsResponse(d2Response).instances[0];
             if (!d2Event) return Future.error(new Error(`Cannot found event: ${id}`));
 
             const orgUnitIds = this.getRelatedIdsFromDataValues(
@@ -146,7 +150,8 @@ export class IssueD2Repository implements IssueRepository {
                 trackedEntity: analysisId,
             })
         ).flatMap(d2Response => {
-            const tei = d2Response.instances.find(tei => tei.trackedEntity === analysisId);
+            const instances = buildTrackerResponse(d2Response).instances;
+            const tei = instances.find(tei => tei.trackedEntity === analysisId);
             if (!tei) return Future.error(new Error(`Cannot found TEI: ${tei}`));
             const enrollment = _(tei.enrollments || []).first();
             if (!enrollment)

--- a/src/data/repositories/QualityAnalysisD2Repository.ts
+++ b/src/data/repositories/QualityAnalysisD2Repository.ts
@@ -4,7 +4,6 @@ import {
     D2TrackerEvent,
     D2Api,
     D2TrackerTrackedEntity,
-    TrackedEntitiesGetResponse,
 } from "$/types/d2-api";
 import {
     QualityAnalysisOptions,

--- a/src/data/repositories/QualityAnalysisD2Repository.ts
+++ b/src/data/repositories/QualityAnalysisD2Repository.ts
@@ -4,6 +4,7 @@ import {
     D2TrackerEvent,
     D2Api,
     D2TrackerTrackedEntity,
+    TrackedEntitiesGetResponse,
 } from "$/types/d2-api";
 import {
     QualityAnalysisOptions,
@@ -35,7 +36,7 @@ import { D2OrgUnit } from "$/data/common/D2Country";
 import { getUid } from "$/utils/uid";
 import { DATA_QUALITY_NAMESPACE } from "$/domain/entities/Settings";
 import { getDefaultModules } from "$/data/common/D2Module";
-import { getProgramStageIndexById } from "$/data/common/utils";
+import { buildTrackerResponse, getProgramStageIndexById } from "$/data/common/utils";
 
 export class QualityAnalysisD2Repository implements QualityAnalysisRepository {
     d2DataElement: D2DataElement;
@@ -67,8 +68,8 @@ export class QualityAnalysisD2Repository implements QualityAnalysisRepository {
                 totalPages: true,
             })
         ).flatMap(d2Response => {
-            const instances = d2Response.instances;
-            const teiIds = _(d2Response.instances)
+            const instances = buildTrackerResponse(d2Response).instances;
+            const teiIds = _(instances)
                 .map(instance => instance.trackedEntity)
                 .compact()
                 .value();
@@ -240,10 +241,9 @@ export class QualityAnalysisD2Repository implements QualityAnalysisRepository {
                 trackedEntity: qaIds.join(";"),
             })
         ).flatMap(d2Response => {
+            const instances = buildTrackerResponse(d2Response).instances;
             const qualityAnalysisToPost = qaIds.map(qaId => {
-                const existingTei = d2Response.instances.find(
-                    d2Tei => d2Tei.trackedEntity === qaId
-                );
+                const existingTei = instances.find(d2Tei => d2Tei.trackedEntity === qaId);
                 const qAnalysis = qualityAnalysis.find(qai => qai.id === qaId);
                 if (!qAnalysis) {
                     throw Error(`Cannot find qualityAnalysis: ${qaId}`);

--- a/src/data/repositories/ValidationRuleAnalysisD2Repository.ts
+++ b/src/data/repositories/ValidationRuleAnalysisD2Repository.ts
@@ -9,11 +9,14 @@ import {
 import { ValidationRule } from "$/domain/entities/ValidationRuleGroup";
 import _ from "$/domain/entities/generic/Collection";
 import { Future } from "$/domain/entities/generic/Future";
+import i18n from "$/utils/i18n";
 
 export class ValidationRuleAnalysisD2Repository implements ValidationRuleAnalysisRepository {
     constructor(private api: D2Api) {}
 
     get(options: ValidationRuleOptions): FutureData<ValidationRuleAnalysis[]> {
+        if (!options.countryId)
+            return Future.error(new Error(i18n.t("Select at least one organisation unit")));
         return apiToFuture(
             this.api.request<D2ValidationRuleAnalysis[]>({
                 method: "post",

--- a/src/domain/entities/QualityAnalysis.ts
+++ b/src/domain/entities/QualityAnalysis.ts
@@ -26,12 +26,31 @@ export class QualityAnalysis extends Struct<QualityAnalysisAttrs>() {
     static build(
         attrs: QualityAnalysisAttrs
     ): Either<ValidationError<QualityAnalysis>[], QualityAnalysis> {
-        const qualityAnalysis = new QualityAnalysis({
-            ...attrs,
-            name: attrs.name,
-        });
+        const qualityAnalysis = new QualityAnalysis({ ...attrs, name: attrs.name });
+        const errors: ValidationError<QualityAnalysis>[] = QualityAnalysis.getErrors(
+            qualityAnalysis,
+            { validateCountries: false }
+        );
+        return errors.length === 0 ? Either.success(qualityAnalysis) : Either.error(errors);
+    }
 
-        const errors: ValidationError<QualityAnalysis>[] = [
+    private static getErrors(
+        qualityAnalysis: QualityAnalysis,
+        options: { validateCountries: boolean }
+    ): ValidationError<QualityAnalysis>[] {
+        const countryProperty = options.validateCountries
+            ? [
+                  {
+                      property: "countriesAnalysis" as const,
+                      errors: validateRequired(
+                          qualityAnalysis.countriesAnalysis,
+                          "country_validation"
+                      ),
+                      value: qualityAnalysis.countriesAnalysis,
+                  },
+              ]
+            : [];
+        return [
             {
                 property: "name" as const,
                 errors: validateRequired(qualityAnalysis.name),
@@ -57,13 +76,19 @@ export class QualityAnalysis extends Struct<QualityAnalysisAttrs>() {
                 errors: validateRequired(qualityAnalysis.status),
                 value: qualityAnalysis.status,
             },
+            ...countryProperty,
         ].filter(validation => validation.errors.length > 0);
+    }
 
-        if (errors.length === 0) {
-            return Either.success(qualityAnalysis);
-        } else {
-            return Either.error(errors);
-        }
+    static updateConfiguration(
+        attrs: QualityAnalysisAttrs
+    ): Either<ValidationError<QualityAnalysis>[], QualityAnalysis> {
+        const qualityAnalysis = this.build(attrs).get();
+        const errors: ValidationError<QualityAnalysis>[] = QualityAnalysis.getErrors(
+            qualityAnalysis,
+            { validateCountries: true }
+        );
+        return errors.length === 0 ? Either.success(qualityAnalysis) : Either.error(errors);
     }
 
     static hasExecutedSections(qualityAnalysis: QualityAnalysis): boolean {
@@ -77,6 +102,7 @@ export class QualityAnalysis extends Struct<QualityAnalysisAttrs>() {
         const formattedDate = date.toISOString().replace(/[-:T.]/g, "_");
         return `${prefix} - ${formattedDate}`;
     }
+
     static isModuleTwo(qualityAnalysis: QualityAnalysis): boolean {
         return qualityAnalysis.module.code === MODULE_2_CODE;
     }

--- a/src/domain/entities/Settings.ts
+++ b/src/domain/entities/Settings.ts
@@ -48,11 +48,6 @@ export class Settings extends Struct<SettingsAttrs>() {
                 errors: validateRequired(settings.startDate),
                 value: settings.startDate,
             },
-            {
-                property: "countryIds" as const,
-                errors: validateRequired(settings.countryIds),
-                value: settings.countryIds,
-            },
         ].filter(validation => validation.errors.length > 0);
 
         if (errors.length === 0) {

--- a/src/domain/entities/generic/Errors.ts
+++ b/src/domain/entities/generic/Errors.ts
@@ -1,8 +1,9 @@
 import i18n from "$/utils/i18n";
 
-export type ValidationErrorKey = "field_cannot_be_blank";
+export type ValidationErrorKey = "field_cannot_be_blank" | "country_validation";
 
 export const validationErrorMessages: Record<ValidationErrorKey, (fieldName: string) => string> = {
+    country_validation: () => i18n.t("Select at least one organisation unit"),
     field_cannot_be_blank: (fieldName: string) =>
         i18n.t(`Cannot be blank: {{fieldName}}`, { fieldName: fieldName, nsSeparator: false }),
 };

--- a/src/domain/entities/generic/validations.ts
+++ b/src/domain/entities/generic/validations.ts
@@ -1,7 +1,14 @@
 import { ValidationErrorKey } from "./Errors";
 
-export function validateRequired(value: any): ValidationErrorKey[] {
+export function validateRequired(
+    value: any,
+    errorCode: ValidationErrorKey = "field_cannot_be_blank"
+): ValidationErrorKey[] {
     const isBlank = !value || (value.length !== undefined && value.length === 0);
 
-    return isBlank ? ["field_cannot_be_blank"] : [];
+    return isBlank ? setErrorCode(errorCode) : [];
+}
+
+function setErrorCode(errorCode?: ValidationErrorKey): ValidationErrorKey[] {
+    return errorCode ? [errorCode] : ["field_cannot_be_blank"];
 }

--- a/src/domain/usecases/CreateQualityAnalysisUseCase.ts
+++ b/src/domain/usecases/CreateQualityAnalysisUseCase.ts
@@ -49,9 +49,7 @@ export class CreateQualityAnalysisUseCase {
                 status: "In Progress",
                 lastModification: "",
                 countriesAnalysis: defaultSettings.countryIds,
-                sequential: {
-                    value: `DQ-${sequential.value}`,
-                },
+                sequential: { value: `DQ-${sequential.value}` },
             }).match({
                 error: errors => {
                     const errorMessages = getErrors(errors);

--- a/src/domain/usecases/GetCountriesByIdsUseCase.ts
+++ b/src/domain/usecases/GetCountriesByIdsUseCase.ts
@@ -1,14 +1,16 @@
 import { FutureData } from "$/data/api-futures";
 import { Country } from "$/domain/entities/Country";
+import { MetadataItem } from "$/domain/entities/MetadataItem";
 import { Id } from "$/domain/entities/Ref";
 import { Future } from "$/domain/entities/generic/Future";
 import { CountryRepository } from "$/domain/repositories/CountryRepository";
 
 export class GetCountriesByIdsUseCase {
-    constructor(private countryRepository: CountryRepository) {}
+    constructor(private countryRepository: CountryRepository, private config: MetadataItem) {}
 
     execute(ids: Id[]): FutureData<Country[]> {
         if (ids.length === 0) return Future.success([]);
+
         return this.countryRepository.getByIds(ids);
     }
 }

--- a/src/domain/usecases/RunOutlierUseCase.ts
+++ b/src/domain/usecases/RunOutlierUseCase.ts
@@ -34,7 +34,8 @@ export class RunOutlierUseCase {
                     analysis.startDate,
                     analysis.endDate,
                     analysis.countriesAnalysis,
-                    dataElements.map(dataElement => dataElement.id)
+                    dataElements.map(dataElement => dataElement.id),
+                    analysis.module.id
                 ).flatMap(outliers => {
                     return this.issueUseCase
                         .getTotalIssuesBySection(analysis, options.sectionId)
@@ -75,7 +76,8 @@ export class RunOutlierUseCase {
         startDate: string,
         endDate: string,
         countryIds: Id[],
-        dataElements: Id[]
+        dataElements: Id[],
+        moduleId: Id
     ): FutureData<Outlier[]> {
         const $requests = _(dataElements)
             .chunk(100)
@@ -85,7 +87,7 @@ export class RunOutlierUseCase {
                     countryIds: countryIds,
                     endDate: endDate,
                     startDate: startDate,
-                    moduleId: undefined,
+                    moduleId: moduleId,
                     threshold: options.threshold,
                     dataElementIds: dataElementsIds,
                 });

--- a/src/domain/usecases/RunValidationsUseCase.ts
+++ b/src/domain/usecases/RunValidationsUseCase.ts
@@ -14,6 +14,7 @@ import { ValidationRuleGroupRepository } from "$/domain/repositories/ValidationR
 import { ValidationRuleGroup } from "$/domain/entities/ValidationRuleGroup";
 import { MetadataItem } from "$/domain/entities/MetadataItem";
 import { CountryRepository } from "$/domain/repositories/CountryRepository";
+import i18n from "$/utils/i18n";
 
 export class RunValidationsUseCase {
     private issueUseCase: UCIssue;
@@ -39,6 +40,8 @@ export class RunValidationsUseCase {
                 options.validationRuleGroupId
             ),
         }).flatMap(({ analysis, validationRuleGroup }) => {
+            if (analysis.countriesAnalysis.length === 0)
+                return Future.error(new Error(i18n.t("Select at least one organisation unit")));
             const checkAllCountries = this.isGlobalInCountries(analysis.countriesAnalysis);
             return this.getAllCountries(checkAllCountries, analysis).flatMap(countriesIds => {
                 return this.getValidationRuleAnalysis(analysis, countriesIds, options).flatMap(

--- a/src/domain/usecases/common/UCDataValue.ts
+++ b/src/domain/usecases/common/UCDataValue.ts
@@ -5,18 +5,25 @@ import { DataValue } from "$/domain/entities/DataValue";
 import { Id, Period } from "$/domain/entities/Ref";
 import { DataValueRepository } from "$/domain/repositories/DataValueRepository";
 import { Future } from "$/domain/entities/generic/Future";
+import i18n from "$/utils/i18n";
 
 export class UCDataValue {
     constructor(private dataValueRepository: DataValueRepository) {}
 
     get(countriesIds: Id[], moduleIds: Id[], periods: Period[]): FutureData<DataValue[]> {
+        if (countriesIds.length === 0)
+            throw new Error(i18n.t("Select at least one organisation unit"));
+
+        const [startDate, endDate] = periods;
+        if (!startDate || !endDate) throw new Error("Invalid period");
+        const periodsToSearch = _.range(Number(startDate), Number(endDate) + 1);
         const $requests = _(countriesIds)
             .chunk(1)
             .map(countryIds => {
                 return this.dataValueRepository.get({
                     moduleIds: moduleIds,
                     countriesIds: countryIds,
-                    period: _(periods).uniq().value(),
+                    period: periodsToSearch.map(period => String(period)),
                 });
             })
             .value();

--- a/src/webapp/components/configuration-form/ConfigurationForm.tsx
+++ b/src/webapp/components/configuration-form/ConfigurationForm.tsx
@@ -12,6 +12,7 @@ import _ from "$/domain/entities/generic/Collection";
 import { Country } from "$/domain/entities/Country";
 import styled from "styled-components";
 import { getDefaultModules } from "$/data/common/D2Module";
+import { Alert } from "@material-ui/lab";
 
 export function getIdFromCountriesPaths(paths: string[]): string[] {
     return _(paths)
@@ -44,7 +45,7 @@ export function useCountries(props: UseCountriesProps) {
 }
 
 export const ConfigurationForm: React.FC<ConfigurationFormProps> = React.memo(props => {
-    const { initialData, onSave } = props;
+    const { initialData, onSave, updateCountry } = props;
     const { api, currentUser, metadata } = useAppContext();
     const { countries } = useCountries({ ids: initialData.countriesAnalysis });
     const [formData, setFormData] = React.useState<QualityAnalysis>(() => {
@@ -60,11 +61,7 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = React.memo(pr
     }, [countries]);
 
     const modules = getDefaultModules(metadata);
-
-    const moduleItems = modules.map(module => ({
-        value: module.id,
-        text: module.name,
-    }));
+    const moduleItems = modules.map(module => ({ value: module.id, text: module.name }));
 
     const onFormSubmit = React.useCallback(
         (e: React.FormEvent<HTMLFormElement>) => {
@@ -104,6 +101,7 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = React.memo(pr
 
     const onOrgUnitsChange = (value: Id[]) => {
         setSelectedOrgUnits(value);
+        updateCountry(value.length > 0);
     };
 
     const disableSave = QualityAnalysis.hasExecutedSections(formData);
@@ -111,6 +109,14 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = React.memo(pr
 
     return (
         <Form onSubmit={onFormSubmit}>
+            {selectedOrgUnits.length === 0 && (
+                <AlertContainer>
+                    <Alert severity="error">
+                        {i18n.t("Select at least one organisation unit")}
+                    </Alert>
+                </AlertContainer>
+            )}
+
             <FormControlsContainer>
                 <StyledTextField
                     inputRef={inputRef}
@@ -154,7 +160,7 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = React.memo(pr
                     onChange={onOrgUnitsChange}
                     selected={selectedOrgUnits}
                     levels={[1, 2, 3]}
-                    selectableLevels={[1, 2, 3]}
+                    selectableLevels={[2, 3]}
                     rootIds={currentUser.countries.map(country => country.id)}
                     withElevation={false}
                 />
@@ -172,6 +178,7 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = React.memo(pr
 type ConfigurationFormProps = {
     initialData: QualityAnalysis;
     onSave: (data: QualityAnalysis) => void;
+    updateCountry: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 type UseCountriesProps = { ids: Id[] };
@@ -205,4 +212,8 @@ const OrgUnitContainer = styled.div<{ $disabled?: boolean }>`
 
 const ActionsContainer = styled.div`
     text-align: right;
+`;
+
+const AlertContainer = styled.div`
+    margin-block: 1em;
 `;

--- a/src/webapp/pages/analysis/steps/ConfigurationStep.tsx
+++ b/src/webapp/pages/analysis/steps/ConfigurationStep.tsx
@@ -11,12 +11,13 @@ import { UpdateAnalysisState } from "$/webapp/pages/analysis/AnalysisPage";
 export type ConfigurationStepProps = {
     analysis: QualityAnalysis;
     updateAnalysis: UpdateAnalysisState;
+    updateCountry: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 const noop = () => {};
 
 export const ConfigurationStep: React.FC<ConfigurationStepProps> = React.memo(props => {
-    const { analysis, updateAnalysis } = props;
+    const { analysis, updateAnalysis, updateCountry } = props;
     const { saveQualityAnalysis } = useAnalysisMethods({
         onSuccess: noop,
         onRemove: noop,
@@ -37,7 +38,11 @@ export const ConfigurationStep: React.FC<ConfigurationStepProps> = React.memo(pr
             <TitleContainer>
                 <StyledTypography variant="h2">{i18n.t("Configuration")}</StyledTypography>
             </TitleContainer>
-            <ConfigurationForm initialData={analysis} onSave={onSave} />
+            <ConfigurationForm
+                updateCountry={updateCountry}
+                initialData={analysis}
+                onSave={onSave}
+            />
         </Container>
     );
 });


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8697ct73j

### :memo: Implementation

- [x] There's a new response schema in v41 for tracker/events endpoints:

Before v41 records are included in property `instances`
```json
{
  "page": 1,
  "total": 0,
  "pageCount": 1,
  "pageSize": 50,
  "instances": [
    
  ]
}
```

In v41 there's a new property `trackedEntities`

```json
{
  "page": 2,
  "pageSize": 1000000,
  "total": 1,
  "pageCount": 1,
  "trackedEntities": [
    
  ]
}
```

Similar for the `/tracker/events` endpoints from `instances` to `events`

- [x] Include dataSet parameter for outlier endpoint (`/api/outlierDetection`) since now is mandatory

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester

#8697ct73j