### PR TITLE
rename parameter to get tracked entities by id

### DIFF
--- a/src/data/repositories/QualityAnalysisD2Repository.ts
+++ b/src/data/repositories/QualityAnalysisD2Repository.ts
@@ -60,7 +60,8 @@ export class QualityAnalysisD2Repository implements QualityAnalysisRepository {
                 program: this.getIdOrThrow(this.metadata.programs.qualityIssues?.id),
                 page: options.pagination.page,
                 pageSize: options.pagination.pageSize,
-                trackedEntity: options.filters.ids ? options.filters.ids.join(";") : undefined,
+                // @ts-ignore
+                trackedEntities: options.filters.ids ? options.filters.ids.join(";") : undefined,
                 attribute: this.buildFilters(options.filters)?.join(",") || undefined,
                 // @ts-ignore
                 order: this.buildOrder(options.sorting) || undefined,

--- a/src/data/repositories/QualityAnalysisD2Repository.ts
+++ b/src/data/repositories/QualityAnalysisD2Repository.ts
@@ -60,6 +60,8 @@ export class QualityAnalysisD2Repository implements QualityAnalysisRepository {
                 program: this.getIdOrThrow(this.metadata.programs.qualityIssues?.id),
                 page: options.pagination.page,
                 pageSize: options.pagination.pageSize,
+                // TODO: Update d2-api to support para "trackedEntities" since "trackedEntity"
+                // is deprecated
                 // @ts-ignore
                 trackedEntities: options.filters.ids ? options.filters.ids.join(";") : undefined,
                 attribute: this.buildFilters(options.filters)?.join(",") || undefined,


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8697ct73j

### :memo: Implementation

- [x] users without full authorities cannot update data qualities (this was not a problem in our code but related to some program trackers not having a tracked entity type associated)

- [x] rename parameter from `trackedEntity` to `trackedEntities`

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester

#8697ct73j