### PR TITLE
fix(outlier): stop chunking DEs to prevent duplicate outlier issues

### DIFF
--- a/src/CompositionRoot.ts
+++ b/src/CompositionRoot.ts
@@ -139,8 +139,7 @@ function getCompositionRoot(repositories: Repositories) {
             run: new RunOutlierUseCase(
                 repositories.outlierRepository,
                 repositories.qualityAnalysisRepository,
-                repositories.issueRepository,
-                repositories.moduleRepository
+                repositories.issueRepository
             ),
         },
         practitioners: {

--- a/src/data/repositories/OutlierD2Repository.ts
+++ b/src/data/repositories/OutlierD2Repository.ts
@@ -9,13 +9,16 @@ export class OutlierD2Repository implements OutlierRepository {
     constructor(private api: D2Api) {}
 
     export(options: OutlierOptions): FutureData<Outlier[]> {
+        // https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-240/data-validation.html#request-query-parameters
+        // The endpoint expects either `ds` (analyze every DE in the data set)
+        // or `de` (analyze specific DEs); when both are sent, `de` is silently ignored
+        // Omitting `ds` returns error E2200.
         return apiToFuture(
             this.api.request<D2OutlierResponse>({
                 method: "get",
                 url: "/outlierDetection",
                 params: {
                     ds: options.moduleId,
-                    de: options.dataElementIds,
                     ou: options.countryIds,
                     startDate: options.startDate,
                     endDate: options.endDate,

--- a/src/domain/repositories/OutlierRepository.ts
+++ b/src/domain/repositories/OutlierRepository.ts
@@ -7,16 +7,6 @@ export interface OutlierRepository {
     export(options: OutlierOptions): FutureData<Outlier[]>;
 }
 
-// DHIS2 /outlierDetection accepts either `ds` (data set, includes all its data
-// elements) or `de` (specific data elements), but not both — when `ds` is
-// provided, `de` is silently ignored and the analysis runs over the full data
-// set. See:
-// https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-240/data-validation.html#request-query-parameters
-// > "You must specify either data sets with the ds parameter, which will
-// > include all data elements in the data sets, or specify data elements with
-// > the de parameter."
-// Because this use case always passes `moduleId` (= `ds`), we intentionally do
-// not expose `dataElementIds` on these options.
 export type OutlierOptions = {
     moduleId: Maybe<Id>;
     countryIds: Id[];

--- a/src/domain/repositories/OutlierRepository.ts
+++ b/src/domain/repositories/OutlierRepository.ts
@@ -7,9 +7,18 @@ export interface OutlierRepository {
     export(options: OutlierOptions): FutureData<Outlier[]>;
 }
 
+// DHIS2 /outlierDetection accepts either `ds` (data set, includes all its data
+// elements) or `de` (specific data elements), but not both — when `ds` is
+// provided, `de` is silently ignored and the analysis runs over the full data
+// set. See:
+// https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-240/data-validation.html#request-query-parameters
+// > "You must specify either data sets with the ds parameter, which will
+// > include all data elements in the data sets, or specify data elements with
+// > the de parameter."
+// Because this use case always passes `moduleId` (= `ds`), we intentionally do
+// not expose `dataElementIds` on these options.
 export type OutlierOptions = {
     moduleId: Maybe<Id>;
-    dataElementIds: Maybe<Id[]>;
     countryIds: Id[];
     startDate: string;
     endDate: string;

--- a/src/domain/usecases/RunOutlierUseCase.ts
+++ b/src/domain/usecases/RunOutlierUseCase.ts
@@ -2,13 +2,9 @@ import { FutureData } from "$/data/api-futures";
 import { Outlier } from "$/domain/entities/Outlier";
 import { QualityAnalysis } from "$/domain/entities/QualityAnalysis";
 import { Id } from "$/domain/entities/Ref";
-import { Future } from "$/domain/entities/generic/Future";
 import { IssueRepository } from "$/domain/repositories/IssueRepository";
 import { OutlierRepository } from "$/domain/repositories/OutlierRepository";
 import { QualityAnalysisRepository } from "$/domain/repositories/QualityAnalysisRepository";
-import _ from "$/domain/entities/generic/Collection";
-import { ModuleRepository } from "$/domain/repositories/ModuleRepository";
-import { DataElement } from "$/domain/entities/DataElement";
 import { UCIssue } from "./common/UCIssue";
 import { UCAnalysis } from "./common/UCAnalysis";
 import { QualityAnalysisIssue } from "$/domain/entities/QualityAnalysisIssue";
@@ -20,8 +16,7 @@ export class RunOutlierUseCase {
     constructor(
         private outlierRepository: OutlierRepository,
         private analysisRepository: QualityAnalysisRepository,
-        private issueRepository: IssueRepository,
-        private moduleRepository: ModuleRepository
+        private issueRepository: IssueRepository
     ) {
         this.analysisUseCase = new UCAnalysis(this.analysisRepository);
         this.issueUseCase = new UCIssue(this.issueRepository);
@@ -31,47 +26,36 @@ export class RunOutlierUseCase {
         return this.analysisUseCase
             .getById(options.qualityAnalysisId, options.metadata)
             .flatMap(analysis => {
-                return this.getNumericDataElements(analysis.module.id).flatMap(dataElements => {
-                    return this.getOutliers(
-                        options,
-                        analysis.startDate,
-                        analysis.endDate,
-                        analysis.countriesAnalysis,
-                        dataElements.map(dataElement => dataElement.id),
-                        analysis.module.id
-                    ).flatMap(outliers => {
-                        return this.issueUseCase
-                            .getTotalIssuesBySection(analysis, options.sectionId, options.metadata)
-                            .flatMap(totalIssues => {
-                                const issues = this.generateIssuesFromOutliers(
-                                    outliers,
-                                    analysis,
-                                    totalIssues,
-                                    options
-                                );
-                                return this.saveIssues(issues, analysis, options);
-                            })
-                            .flatMap(() => {
-                                const analysisToUpdate = this.analysisUseCase.updateAnalysis(
-                                    analysis,
-                                    options.sectionId,
-                                    outliers.length
-                                );
-                                return this.analysisRepository
-                                    .save([analysisToUpdate], options.metadata)
-                                    .map(() => analysisToUpdate);
-                            });
-                    });
+                return this.getOutliers(
+                    options,
+                    analysis.startDate,
+                    analysis.endDate,
+                    analysis.countriesAnalysis,
+                    analysis.module.id
+                ).flatMap(outliers => {
+                    return this.issueUseCase
+                        .getTotalIssuesBySection(analysis, options.sectionId, options.metadata)
+                        .flatMap(totalIssues => {
+                            const issues = this.generateIssuesFromOutliers(
+                                outliers,
+                                analysis,
+                                totalIssues,
+                                options
+                            );
+                            return this.saveIssues(issues, analysis, options);
+                        })
+                        .flatMap(() => {
+                            const analysisToUpdate = this.analysisUseCase.updateAnalysis(
+                                analysis,
+                                options.sectionId,
+                                outliers.length
+                            );
+                            return this.analysisRepository
+                                .save([analysisToUpdate], options.metadata)
+                                .map(() => analysisToUpdate);
+                        });
                 });
             });
-    }
-
-    private getNumericDataElements(moduleId: Id): FutureData<DataElement[]> {
-        return this.moduleRepository.getByIds([moduleId]).flatMap(modules => {
-            const module = modules[0];
-            if (!module) return Future.error(new Error(`Cannot find module: ${moduleId}`));
-            return Future.success(module.dataElements.filter(dataElement => dataElement.isNumber));
-        });
     }
 
     private getOutliers(
@@ -79,25 +63,15 @@ export class RunOutlierUseCase {
         startDate: string,
         endDate: string,
         countryIds: Id[],
-        dataElements: Id[],
         moduleId: Id
     ): FutureData<Outlier[]> {
-        const $requests = _(dataElements)
-            .chunk(100)
-            .map(dataElementsIds => {
-                return this.outlierRepository.export({
-                    algorithm: options.algorithm,
-                    countryIds: countryIds,
-                    endDate: endDate,
-                    startDate: startDate,
-                    moduleId: moduleId,
-                    threshold: options.threshold,
-                    dataElementIds: dataElementsIds,
-                });
-            })
-            .value();
-        return Future.sequential($requests).flatMap(result => {
-            return Future.success(_(result).flatten().value());
+        return this.outlierRepository.export({
+            algorithm: options.algorithm,
+            countryIds: countryIds,
+            endDate: endDate,
+            startDate: startDate,
+            moduleId: moduleId,
+            threshold: options.threshold,
         });
     }
 


### PR DESCRIPTION
### :pushpin: References

- **Issue:** Closes #869cv4ywk
- [Data Quality issue - 7 Issues created on Outliers Detection instead of 1](https://app.clickup.com/t/869cv4ywk)

### :memo: Implementation
**Issue:** `RunOutlierUseCase` was splitting the module's numeric data elements into chunks of 100 and calling `/outlierDetection` once per chunk. DHIS2's `/outlierDetection` endpoint, however, [requires either `ds` **or** `de`](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-240/data-validation.html#request-query-parameters), and silently ignores `de` when `ds` is provided. Since this use case always passes `ds` (the module id), every chunked request ran the **same** full-dataset analysis creating the same issue for each chunk

**Fix:**
- Drop the chunking in `RunOutlierUseCase.getOutliers` — a single request per run.
- Remove `dataElementIds` from `OutlierOptions` and from `OutlierD2Repository` entirely


### :video_camera: Screenshots/Screen capture
Tested changes in release 1.3.1
https://portal-uat.who.int/dhis2/api/apps/NHWA-Data-Quality/index.html#/analysis/qEKGH9VysoM
<img width="1204" height="822" alt="image" src="https://github.com/user-attachments/assets/10ba498f-ccc9-44ed-9001-715a88d3d0e1" />


### :fire: Notes to the tester