### PR TITLE
feat(validation): display validation error descriptions with structur…

### DIFF
--- a/src/domain/usecases/RunValidationsUseCase.ts
+++ b/src/domain/usecases/RunValidationsUseCase.ts
@@ -149,11 +149,14 @@ export class RunValidationsUseCase {
         validationRuleGroup: ValidationRuleGroup,
         rule: ValidationRuleAnalysis
     ): string {
-        if (rule.validationRule.description) {
-            return `Validation Rule ${rule.validationRule.name} - ${rule.validationRule.description} associated to the Validation Rule Group ${validationRuleGroup.name} failed: ${rule.leftValue} ${rule.operator} ${rule.rightValue}`;
-        } else {
-            return `Validation Rule ${rule.validationRule.name} associated to the Validation Rule Group ${validationRuleGroup.name} failed: ${rule.leftValue} ${rule.operator} ${rule.rightValue}`;
-        }
+        const rulePart = rule.validationRule.description
+            ? `${rule.validationRule.name} - ${rule.validationRule.description}`
+            : rule.validationRule.name;
+        return [
+            `Rule Group: ${validationRuleGroup.name}`,
+            `Rule: ${rulePart}`,
+            `Values: ${rule.leftValue} ${rule.operator} ${rule.rightValue}`,
+        ].join("\n");
     }
 
     private saveIssues(

--- a/src/webapp/components/issues/IssueColumns.tsx
+++ b/src/webapp/components/issues/IssueColumns.tsx
@@ -33,15 +33,23 @@ export function useIssueColumns() {
                 text: i18n.t("Description"),
                 sortable: false,
                 getValue: (issue: QualityAnalysisIssue) => {
-                    const desc = issue.description;
-                    if (!desc.startsWith("Rule Group: ")) return desc;
-                    const [groupLine, ruleLine, valuesLine] = desc.split("\n");
-                    const label = (prefix: string, line: string | undefined) => (
+                    const description = issue.description;
+                    const [groupLine, ruleLine, valuesLine] = description.split("\n");
+
+                    const isStructured =
+                        groupLine?.startsWith("Rule Group: ") &&
+                        ruleLine?.startsWith("Rule: ") &&
+                        valuesLine?.startsWith("Values: ");
+
+                    if (!isStructured) return description;
+
+                    const label = (prefix: string, line: string) => (
                         <>
                             <strong>{prefix}</strong>
-                            {line?.slice(prefix.length) ?? ""}
+                            {line.slice(prefix.length)}
                         </>
                     );
+
                     return (
                         <span>
                             {label("Rule Group:", groupLine)}

--- a/src/webapp/components/issues/IssueColumns.tsx
+++ b/src/webapp/components/issues/IssueColumns.tsx
@@ -52,11 +52,11 @@ export function useIssueColumns() {
 
                     return (
                         <span>
-                            {label("Rule Group:", groupLine)}
+                            {label("Rule Group:", groupLine!)}
                             <br />
-                            {label("Rule:", ruleLine)}
+                            {label("Rule:", ruleLine!)}
                             <br />
-                            {label("Values:", valuesLine)}
+                            {label("Values:", valuesLine!)}
                         </span>
                     );
                 },

--- a/src/webapp/components/issues/IssueColumns.tsx
+++ b/src/webapp/components/issues/IssueColumns.tsx
@@ -43,6 +43,11 @@ export function useIssueColumns() {
 
                     if (!isStructured) return description;
 
+                    // guaranteed non-undefined by isStructured check above
+                    const group = groupLine ?? "";
+                    const rule = ruleLine ?? "";
+                    const values = valuesLine ?? "";
+
                     const label = (prefix: string, line: string) => (
                         <>
                             <strong>{prefix}</strong>
@@ -52,11 +57,11 @@ export function useIssueColumns() {
 
                     return (
                         <span>
-                            {label("Rule Group:", groupLine!)}
+                            {label("Rule Group:", group)}
                             <br />
-                            {label("Rule:", ruleLine!)}
+                            {label("Rule:", rule)}
                             <br />
-                            {label("Values:", valuesLine!)}
+                            {label("Values:", values)}
                         </span>
                     );
                 },

--- a/src/webapp/components/issues/IssueColumns.tsx
+++ b/src/webapp/components/issues/IssueColumns.tsx
@@ -32,6 +32,26 @@ export function useIssueColumns() {
                 name: "description",
                 text: i18n.t("Description"),
                 sortable: false,
+                getValue: (issue: QualityAnalysisIssue) => {
+                    const desc = issue.description;
+                    if (!desc.startsWith("Rule Group: ")) return desc;
+                    const [groupLine, ruleLine, valuesLine] = desc.split("\n");
+                    const label = (prefix: string, line: string | undefined) => (
+                        <>
+                            <strong>{prefix}</strong>
+                            {line?.slice(prefix.length) ?? ""}
+                        </>
+                    );
+                    return (
+                        <span>
+                            {label("Rule Group:", groupLine)}
+                            <br />
+                            {label("Rule:", ruleLine)}
+                            <br />
+                            {label("Values:", valuesLine)}
+                        </span>
+                    );
+                },
             },
             {
                 name: "status",


### PR DESCRIPTION
- Replace flat sentence format with three-line labeled structure:
  Rule Group: <group name>
  Rule: <rule name and description>
  Values: <left operator right>
- Add custom renderer in IssueColumns to detect and format new structure
- Maintains backward compatibility with old plain-text descriptions
- Improves readability of validation issues in data quality reports

### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869d8v41m

### :memo: Implementation

### :video_camera: Screenshots/Screen capture
<img width="1802" height="1080" alt="Screenshot 2026-05-12 at 12 45 49" src="https://github.com/user-attachments/assets/03af0a36-a420-4803-be80-368247c66b1b" />


### :fire: Notes to the tester
code created with Claude as a benchmark for coding on a simple task
