### PR TITLE
fix: 2.42 support - removal of userCredentials 

### DIFF
--- a/src/data/common/D2User.ts
+++ b/src/data/common/D2User.ts
@@ -73,7 +73,12 @@ export class D2User {
             }),
             countries: [...readAccessCountries, ...writeAccessCountries],
             email: d2User.email,
-            ...d2User.userCredentials,
+            // @ts-expect-error - upgrade d2-api for up-to-date types
+            lastLogin: d2User.lastLogin,
+            // @ts-expect-error - upgrade d2-api for up-to-date types
+            username: d2User.username,
+            // @ts-expect-error - upgrade d2-api for up-to-date types
+            userRoles: d2User.userRoles,
         });
     }
 }
@@ -83,11 +88,9 @@ const userFields = {
     displayName: true,
     email: true,
     userGroups: { id: true, name: true, users: true },
-    userCredentials: {
-        lastLogin: true,
-        username: true,
-        userRoles: { id: true, name: true, authorities: true },
-    },
+    lastLogin: true,
+    username: true,
+    userRoles: { id: true, name: true, authorities: true },
     teiSearchOrganisationUnits: { id: true, name: true, path: true },
     organisationUnits: { id: true, name: true, path: true },
 } as const;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869dd3tm3

### :memo: Implementation

- Under DHIS 2.42  the app was failing to initialize due to the removal of the `userCredentials` property. The properties that were there are now included in the top-level User object.
- This PR no longer supports instances where `lastLogin`, `username`, and `userRoles` are only available under `userCredentials`. At least versions equal or greater than 2.40 are supported.

**Alternatives explored:** 
- Considered fetching these props from both top-level User and `userCredentials` to maintain backwards compatibility, but discarded that approach to avoid big responses in 2.40/2.41, which would return the fields duplicated in both places. There might be instances of users with a considerable amount of roles/authorities.
  - Maybe not a real concern at network level using compression, but more a serialization/parse overhead.
- Tried upgrading d2-api to a version with proper typings for this response (at least 1.18.0), but a lot of other unrelated typing errors surfaced. Opted to keep this simple and focused, and handle the d2-api upgrade in a follow-up.
  - This is why `@ts-expect-error` comments were added temporarily

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester
