### PR TITLE
Issues/Bugs detected during Webinar prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,19 @@ The application supports the analysis steps described below and can also support
 > If the configuration in this DataStore entry is incorrect,
 > custom analysis steps will not be displayed or executed correctly.
 
+> **Program Stage naming (required)**
+>
+> The application maps each Program Stage to an analysis step **by its `name`**. Some DHIS2 versions require Program Stage names to be unique across the **whole instance**, not just within their own program. To avoid that conflict, Program Stage names **must** now be prefixed with the same prefix used for the Tracker Program code, followed by an underscore
+> (for example: `TEST_DQI_001_Outliers`, `TEST_DQI_001_Validation`, `TEST_DQI_001_Manual Issues`). This applies to every program, including the first one.
+>
+> **Deprecated:** the plain, unprefixed name (for example: `Outliers`, with no prefix) is no longer a valid convention for new configurations. It is only supported for **backward compatibility** with Program Stages created before this requirement — the application still recognizes it, but it must not be used when creating new Data Quality programs.
+
 ##### Program Stage: Outliers
 
 This Program Stage is used to store **data quality issues detected through outlier analysis**,
 based on the standard DHIS2 min–max outlier detection functionality.
 
--   **Name:** Outliers
+-   **Name:** `PREFIX_DQI_001_Outliers` (`Outliers`, without prefix, is deprecated — see "Program Stage naming" note above)
 -   **Scheduled days from start:** `0`
 -   **Repeatable:** enabled
 -   **Auto-generate event:** enabled
@@ -79,7 +86,7 @@ All other options should remain with their default values.
 
 This Program Stage is used to store **data quality issues detected through validation rules analysis**.
 
--   **Name:** Validation
+-   **Name:** `PREFIX_DQI_001_Validation` (`Validation`, without prefix, is deprecated — see "Program Stage naming" note above)
 -   **Scheduled days from start:** `1`
 -   **Repeatable:** enabled
 -   **Auto-generate event:** enabled
@@ -93,7 +100,7 @@ All other options should remain with their default values.
 This Program Stage is used to **manually register data quality issues**
 that cannot be automatically detected through data analysis.
 
--   **Name:** Manual Issues
+-   **Name:** `PREFIX_DQI_001_Manual Issues` (`Manual Issues`, without prefix, is deprecated — see "Program Stage naming" note above)
 -   **Scheduled days from start:** `0`
 -   **Repeatable:** enabled
 -   **Auto-generate event:** enabled

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The following Option Sets **must exist**:
 
     -   Name: No action — Code: `0`
     -   Name: Data modification from HQ — Code: `1`
-    -   Name: Data modification from country — Code: `2`
+    -   Name: Data modification from Organisation Unit — Code: `2`
 
 -   `PREFIX_DQI_Status`
     -   Name: Not treated — Code: `0`

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -20,7 +20,7 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-msgid "Country"
+msgid "Org Unit"
 msgstr ""
 
 msgid "Data Element"
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Issue"
 msgstr ""
 
-msgid "{{countryNames}} and {{moreCountriesCount}} more"
+msgid "{{orgUnitNames}} and {{moreOrgUnitsCount}} more"
 msgstr ""
 
 msgid "Close"
@@ -163,7 +163,7 @@ msgstr ""
 msgid "Issue Number"
 msgstr ""
 
-msgid "Countries"
+msgid "Org Units"
 msgstr ""
 
 msgid "Step"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -20,7 +20,7 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-msgid "Country"
+msgid "Org Unit"
 msgstr ""
 
 msgid "Data Element"
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Issue"
 msgstr ""
 
-msgid "{{countryNames}} and {{moreCountriesCount}} more"
+msgid "{{orgUnitNames}} and {{moreOrgUnitsCount}} more"
 msgstr ""
 
 msgid "Close"
@@ -163,7 +163,7 @@ msgstr ""
 msgid "Issue Number"
 msgstr ""
 
-msgid "Countries"
+msgid "Org Units"
 msgstr ""
 
 msgid "Step"

--- a/src/data/repositories/IssueSpreadSheetRepository.ts
+++ b/src/data/repositories/IssueSpreadSheetRepository.ts
@@ -27,7 +27,7 @@ export class IssueSpreadSheetRepository implements IssueExportRepository {
                         number: { title: i18n.t("Number") },
                         azureUrl: { title: i18n.t("Azure URL") },
                         period: { title: i18n.t("Period") },
-                        country: { title: i18n.t("Country") },
+                        country: { title: i18n.t("Org Unit") },
                         dataElement: { title: i18n.t("Data Element") },
                         categoryOption: { title: i18n.t("Category") },
                         description: { title: i18n.t("Description") },

--- a/src/data/repositories/QualityAnalysisD2Repository.ts
+++ b/src/data/repositories/QualityAnalysisD2Repository.ts
@@ -38,7 +38,7 @@ import { buildTrackerResponse, getProgramStageIndexById } from "$/data/common/ut
 import { DATA_QUALITY_NAMESPACE } from "$/data/common/DataStoreConfig";
 import { DataStore } from "@eyeseetea/d2-api/api";
 
-const DEFAULT_PAGE_SIZE = 150;
+const DEFAULT_PAGE_SIZE = 500;
 const DEFAULT_DELETE_CHUNK_SIZE = 300;
 
 export class QualityAnalysisD2Repository implements QualityAnalysisRepository {
@@ -116,7 +116,7 @@ export class QualityAnalysisD2Repository implements QualityAnalysisRepository {
             },
             pagination: {
                 page: 1,
-                pageSize: 1e6,
+                pageSize: DEFAULT_PAGE_SIZE,
             },
             sorting: {
                 field: "name",

--- a/src/domain/entities/StepSettings.ts
+++ b/src/domain/entities/StepSettings.ts
@@ -53,5 +53,13 @@ const NAME_TO_STEP_TYPE: Record<string, StepType> = {
 
 export function resolveStepTypeFromSectionName(name: string): StepType | undefined {
     const key = normalizeSectionNameToKey(name);
-    return NAME_TO_STEP_TYPE[key];
+
+    const exactMatch = NAME_TO_STEP_TYPE[key];
+    if (exactMatch) return exactMatch;
+
+    const prefixedMatch = Object.entries(NAME_TO_STEP_TYPE).find(([canonicalKey]) =>
+        key.endsWith(`_${canonicalKey}`)
+    );
+
+    return prefixedMatch?.[1];
 }

--- a/src/domain/entities/__tests__/StepSettings.spec.ts
+++ b/src/domain/entities/__tests__/StepSettings.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { resolveStepTypeFromSectionName } from "$/domain/entities/StepSettings";
+
+describe("resolveStepTypeFromSectionName", () => {
+    it("matches the exact canonical name, with no prefix (deprecated, backward compatibility only)", () => {
+        expect(resolveStepTypeFromSectionName("Outliers")).toBe("OUTLIERS");
+        expect(resolveStepTypeFromSectionName("Validation")).toBe("VALIDATION");
+        expect(resolveStepTypeFromSectionName("Manual Issues")).toBe("MANUAL_ISSUES");
+    });
+
+    it("matches a program-prefixed name (the required convention going forward)", () => {
+        expect(resolveStepTypeFromSectionName("TEST_DQI_001_Outliers")).toBe("OUTLIERS");
+        expect(resolveStepTypeFromSectionName("TEST_DQI_002_Validation")).toBe("VALIDATION");
+        expect(resolveStepTypeFromSectionName("TEST_DQI_001_Manual Issues")).toBe("MANUAL_ISSUES");
+    });
+
+    it("matches a program-prefixed name for multi-word step names", () => {
+        expect(resolveStepTypeFromSectionName("TEST_DQI_001_Double Counts And Missing GP")).toBe(
+            "DOUBLE_COUNTS_AND_MISSING_GP"
+        );
+        expect(resolveStepTypeFromSectionName("TEST_DQI_001_Missing Nurses")).toBe(
+            "MISSING_NURSES"
+        );
+        expect(resolveStepTypeFromSectionName("TEST_DQI_001_Disaggregates")).toBe("DISAGGREGATES");
+    });
+
+    it("is case-insensitive and tolerant of extra whitespace, prefixed or not", () => {
+        expect(resolveStepTypeFromSectionName("  outliers  ")).toBe("OUTLIERS");
+        expect(resolveStepTypeFromSectionName("test_dqi_001_outliers")).toBe("OUTLIERS");
+    });
+
+    it("does not match a name that only contains the canonical name as a substring, with no underscore boundary", () => {
+        expect(resolveStepTypeFromSectionName("OutliersExtra")).toBeUndefined();
+        expect(resolveStepTypeFromSectionName("SubOutliers")).toBeUndefined();
+    });
+
+    it("returns undefined for a name that matches nothing, prefixed or not", () => {
+        expect(resolveStepTypeFromSectionName("Custom Stage")).toBeUndefined();
+        expect(resolveStepTypeFromSectionName("TEST_DQI_001_Custom Stage")).toBeUndefined();
+    });
+});

--- a/src/domain/usecases/UpdateStatusAnalysisUseCase.ts
+++ b/src/domain/usecases/UpdateStatusAnalysisUseCase.ts
@@ -21,7 +21,7 @@ export class UpdateStatusAnalysisUseCase {
                 },
                 pagination: {
                     page: 1,
-                    pageSize: 1e6,
+                    pageSize: ids.length,
                 },
                 sorting: {
                     field: "name",

--- a/src/webapp/components/country-selector/CountrySelector.tsx
+++ b/src/webapp/components/country-selector/CountrySelector.tsx
@@ -3,7 +3,6 @@ import { OrgUnitsSelector } from "@eyeseetea/d2-ui-components";
 
 import { D2Api } from "$/types/d2-api";
 import { Id } from "$/domain/entities/Ref";
-import { ORG_UNIT_LEVELS } from "$/webapp/utils/form";
 
 export const CountrySelector: React.FC<CountrySelectorProps> = props => {
     const { api, onChange, rootIds, selectedCountriesIds: selectedOrgUnits } = props;
@@ -17,8 +16,6 @@ export const CountrySelector: React.FC<CountrySelectorProps> = props => {
             api={api}
             onChange={onOrgUnitsChange}
             selected={selectedOrgUnits}
-            levels={ORG_UNIT_LEVELS}
-            selectableLevels={ORG_UNIT_LEVELS}
             rootIds={rootIds}
             withElevation={false}
         />

--- a/src/webapp/components/issues/EditIssueValue.tsx
+++ b/src/webapp/components/issues/EditIssueValue.tsx
@@ -7,9 +7,11 @@ import { SelectorInline } from "./SelectorInline";
 import { useAppContext } from "$/webapp/contexts/app-context";
 import { SnackbarState, useLoading, useSnackbar } from "@eyeseetea/d2-ui-components";
 import { Id } from "$/domain/entities/Ref";
+import { MetadataItem } from "$/domain/entities/MetadataItem";
 import i18n from "$/utils/i18n";
 import { useParams } from "react-router-dom";
 import { useMetadataItemContext } from "$/webapp/contexts/metadata-item-context";
+import { hasUserGroups, shouldNotifyNoContactUser } from "$/webapp/components/issues/utils";
 
 type UpdateIssuePropertyProps = {
     analysisId: Id;
@@ -22,9 +24,17 @@ function getContactEmailNotification(
     field: IssuePropertyName,
     value: boolean,
     emailChanged: boolean,
+    metadataItem: MetadataItem,
     snackbar: SnackbarState
 ) {
-    if (field === "followUp" && value === true && !emailChanged) {
+    if (
+        shouldNotifyNoContactUser({
+            field,
+            value,
+            emailChanged,
+            userGroupsConfigured: hasUserGroups(metadataItem.userGroups),
+        })
+    ) {
         snackbar.warning(
             i18n.t(
                 "No user with Capture rights and Organisation Unit or Region associated to the issue was found"
@@ -60,6 +70,7 @@ export function useUpdateIssueProperty(props: UpdateIssuePropertyProps) {
                             field,
                             value as boolean,
                             Boolean(result.contactEmailsChanged),
+                            metadataItem,
                             snackbar
                         );
                     },

--- a/src/webapp/components/issues/IssueColumns.tsx
+++ b/src/webapp/components/issues/IssueColumns.tsx
@@ -15,7 +15,7 @@ export function useIssueColumns() {
     const issueColumns = React.useMemo(() => {
         const baseColumns: TableColumn<QualityAnalysisIssue>[] = [
             { name: "number", text: i18n.t("Issue"), sortable: true },
-            { name: "country", text: i18n.t("Country"), sortable: false },
+            { name: "country", text: i18n.t("Org Unit"), sortable: false },
             {
                 name: "period",
                 text: i18n.t("Period"),

--- a/src/webapp/components/issues/IssueFilters.tsx
+++ b/src/webapp/components/issues/IssueFilters.tsx
@@ -36,9 +36,9 @@ function extractCountriesNames(countries: Country[], totalCountriesSelected: num
 
     const countryNamesString =
         moreCountriesCount > 0
-            ? i18n.t("{{countryNames}} and {{moreCountriesCount}} more", {
-                  countryNames,
-                  moreCountriesCount,
+            ? i18n.t("{{orgUnitNames}} and {{moreOrgUnitsCount}} more", {
+                  orgUnitNames: countryNames,
+                  moreOrgUnitsCount: moreCountriesCount,
               })
             : countryNames;
 
@@ -132,7 +132,7 @@ export const IssueFilters: React.FC<IssueFiltersProps> = props => {
             <div>
                 <TextField
                     name="countries"
-                    label={i18n.t("Countries")}
+                    label={i18n.t("Org Units")}
                     onClick={onClickCountry}
                     title={countryNamesString}
                     value={countryNamesString}

--- a/src/webapp/components/issues/__tests__/utils.spec.ts
+++ b/src/webapp/components/issues/__tests__/utils.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { hasUserGroups, shouldNotifyNoContactUser } from "$/webapp/components/issues/utils";
+import { NHWAUserGroups } from "$/domain/entities/MetadataItem";
+
+const populatedUserGroups: NHWAUserGroups = {
+    dataCaptureModule1: { id: "1", name: "Module 1", code: "M1", users: [{ id: "u1" }] },
+    dataCaptureModule2And4: { id: "2", name: "Module 2 and 4", code: "M2", users: [{ id: "u2" }] },
+};
+
+describe("shouldNotifyNoContactUser", () => {
+    it("returns false when the feature is not configured, followUp is checked and no email was generated", () => {
+        const result = shouldNotifyNoContactUser({
+            field: "followUp",
+            value: true,
+            emailChanged: false,
+            userGroupsConfigured: false,
+        });
+
+        expect(result).toBe(false);
+    });
+
+    it("returns true when the feature is configured, followUp is checked and no email was generated", () => {
+        const result = shouldNotifyNoContactUser({
+            field: "followUp",
+            value: true,
+            emailChanged: false,
+            userGroupsConfigured: true,
+        });
+
+        expect(result).toBe(true);
+    });
+
+    it("returns false when the feature is configured, followUp is checked and an email was generated", () => {
+        const result = shouldNotifyNoContactUser({
+            field: "followUp",
+            value: true,
+            emailChanged: true,
+            userGroupsConfigured: true,
+        });
+
+        expect(result).toBe(false);
+    });
+
+    it("returns false for updates to a field other than followUp", () => {
+        const result = shouldNotifyNoContactUser({
+            field: "status",
+            value: true,
+            emailChanged: false,
+            userGroupsConfigured: true,
+        });
+
+        expect(result).toBe(false);
+    });
+
+    it("returns false when followUp is being unset", () => {
+        const result = shouldNotifyNoContactUser({
+            field: "followUp",
+            value: false,
+            emailChanged: false,
+            userGroupsConfigured: true,
+        });
+
+        expect(result).toBe(false);
+    });
+});
+
+describe("hasUserGroups", () => {
+    it("returns false when userGroups is undefined", () => {
+        expect(hasUserGroups(undefined)).toBe(false);
+    });
+
+    it("returns false when userGroups is an empty object", () => {
+        expect(hasUserGroups({} as NHWAUserGroups)).toBe(false);
+    });
+
+    it("returns true when userGroups is populated", () => {
+        expect(hasUserGroups(populatedUserGroups)).toBe(true);
+    });
+});

--- a/src/webapp/components/issues/utils.ts
+++ b/src/webapp/components/issues/utils.ts
@@ -1,6 +1,17 @@
 import { NHWAUserGroups } from "$/domain/entities/MetadataItem";
+import { IssuePropertyName } from "$/domain/entities/QualityAnalysisIssue";
 import { Maybe } from "$/utils/ts-utils";
 
 export function hasUserGroups(userGroups: Maybe<NHWAUserGroups>): boolean {
     return !!userGroups && Object.keys(userGroups).length > 0;
+}
+
+export function shouldNotifyNoContactUser(params: {
+    field: IssuePropertyName;
+    value: boolean;
+    emailChanged: boolean;
+    userGroupsConfigured: boolean;
+}): boolean {
+    const { field, value, emailChanged, userGroupsConfigured } = params;
+    return userGroupsConfigured && field === "followUp" && value === true && !emailChanged;
 }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #869dek93h [Issues/Bugs detected during Webinar prep](https://app.clickup.com/t/869dek93h)

### :memo: Implementation
- OrgUnit is called 'Country' renamed to OrgUnit 
- Follow-up checkbox displays warning saying 'No user with Capture rights and Organisation Unit or Region associated to the issue was found' → warning only appears if the feature is configured at Datastore level
- In setup wizard in step 4 Steps Configuration: every program stage is mapped to a step type based on the name of the program stage: Outliers, Validation or Manual Issues. But now in new versions of DHIS2 the name of the program stages must be unique so we cannot use the name to map to the step types:
> The application maps each Program Stage to an analysis step **by its `name`**. Some DHIS2 versions require Program Stage names to be unique across the **whole instance**, not just within their own program. To avoid that conflict, Program Stage names **must** now be prefixed with the same prefix used for the Tracker Program code, followed by an underscore
> (for example: `TEST_DQI_001_Outliers`, `TEST_DQI_001_Validation`, `TEST_DQI_001_Manual Issues`). This applies to every program, including the first one.
>
> **Deprecated:** the plain, unprefixed name (for example: `Outliers`, with no prefix) is no longer a valid convention for new configurations. It is only supported for **backward compatibility** with Program Stages created before this requirement — the application still recognizes it, but it must not be used when creating new Data Quality programs.

- Fix 1M of TEI pagination → avoid 1e6 pageSize exceeding TEI pagination limit
- Show all OrgUnit levels in the issue filter selector


### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester
