### PR TITLE
Issues/Bugs detected during Webinar prep - Support all period types not only year

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ The following Tracked Entity Attributes **must exist** (codes must match exactly
 -   `PREFIX_DQI_TEA_Name`
 -   `PREFIX_DQI_TEA_Dataset`
 -   `PREFIX_DQI_TEA_Status`
--   `PREFIX_DQI_TEA_Start_Date`
--   `PREFIX_DQI_TEA_End_Date`
+-   `PREFIX_DQI_TEA_Start_Date` — **DATE**
+-   `PREFIX_DQI_TEA_End_Date` — **DATE**
+    -   Both must use the **DATE** value type (not the default **TEXT**); program configuration validation fails if either value type is not `DATE`.
 -   `PREFIX_DQI_TEA_Last_Modification`
 -   `PREFIX_DQI_TEA_Countries_Analysis` — **LONG_TEXT**
 -   `PREFIX_DQI_TEA_Sequential` — **TEXT**

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-02-05T11:05:05.516Z\n"
-"PO-Revision-Date: 2026-02-05T11:05:05.516Z\n"
+"POT-Creation-Date: 2026-07-16T10:04:40.196Z\n"
+"PO-Revision-Date: 2026-07-16T10:04:40.196Z\n"
 
 msgid "ID"
 msgstr ""
@@ -83,6 +83,9 @@ msgstr ""
 msgid "At least one disaggregation is required"
 msgstr ""
 
+msgid "All selected datasets must share the same periodicity (period type)"
+msgstr ""
+
 msgid "No disaggregations selected"
 msgstr ""
 
@@ -120,6 +123,9 @@ msgid "End Date"
 msgstr ""
 
 msgid "New Data Quality Report"
+msgstr ""
+
+msgid "Start Date must not be later than End Date"
 msgstr ""
 
 msgid "Name"
@@ -360,7 +366,7 @@ msgstr ""
 msgid "No datasets are available for data quality analysis."
 msgstr ""
 
-msgid "Use previous year for start and end dates"
+msgid "Use previous period for start and end dates"
 msgstr ""
 
 msgid "No match found for this step, so it cannot be configured."

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-07-16T10:04:40.196Z\n"
-"PO-Revision-Date: 2026-07-16T10:04:40.196Z\n"
+"POT-Creation-Date: 2026-07-16T16:41:44.135Z\n"
+"PO-Revision-Date: 2026-07-16T16:41:44.135Z\n"
 
 msgid "ID"
 msgstr ""
@@ -191,6 +191,9 @@ msgid "Export"
 msgstr ""
 
 msgid "Extend Follow-Up + Contact Emails"
+msgstr ""
+
+msgid "Could not load analysis period information: {{message}}"
 msgstr ""
 
 msgid "Removing..."

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2026-07-16T10:04:40.196Z\n"
+"POT-Creation-Date: 2026-07-16T16:41:44.135Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -191,6 +191,9 @@ msgid "Export"
 msgstr ""
 
 msgid "Extend Follow-Up + Contact Emails"
+msgstr ""
+
+msgid "Could not load analysis period information: {{message}}"
 msgstr ""
 
 msgid "Removing..."

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2026-02-05T11:05:05.516Z\n"
+"POT-Creation-Date: 2026-07-16T10:04:40.196Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -83,6 +83,9 @@ msgstr ""
 msgid "At least one disaggregation is required"
 msgstr ""
 
+msgid "All selected datasets must share the same periodicity (period type)"
+msgstr ""
+
 msgid "No disaggregations selected"
 msgstr ""
 
@@ -120,6 +123,9 @@ msgid "End Date"
 msgstr ""
 
 msgid "New Data Quality Report"
+msgstr ""
+
+msgid "Start Date must not be later than End Date"
 msgstr ""
 
 msgid "Name"
@@ -361,7 +367,7 @@ msgstr ""
 msgid "No datasets are available for data quality analysis."
 msgstr ""
 
-msgid "Use previous year for start and end dates"
+msgid "Use previous period for start and end dates"
 msgstr ""
 
 msgid "No match found for this step, so it cannot be configured."

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "eslint-plugin-no-relative-import-paths": "^1.5.3",
         "font-awesome": "4.7.0",
         "lodash": "4.17.21",
+        "moment": "2.29.4",
         "purify-ts-extra-codec": "0.6.0",
         "purify-ts": "2.0.3",
         "react-dom": "^18.2.0",

--- a/src/data/common/DefaultConfigDatastore.ts
+++ b/src/data/common/DefaultConfigDatastore.ts
@@ -1,0 +1,22 @@
+import { Id } from "$/domain/entities/Ref";
+
+// Raw datastore shape of `settings-<programCode>.defaultConfig`. The auto-fill flag is
+// stored under the deprecated `usePreviousYear` key on legacy records and under
+// `usePreviousPeriod` on records saved after the periodicity change. Reads honor
+// `usePreviousYear` first (retro-compatibility); saves persist `usePreviousPeriod`
+// only, dropping the legacy key (a lazy per-record upgrade, no bulk migration).
+export type DefaultConfigDatastore = {
+    dataSet: string;
+    startDate: string;
+    endDate: string;
+    orgUnits: Id[];
+    usePreviousPeriod?: boolean;
+    usePreviousYear?: boolean;
+};
+
+export function readUsePreviousPeriod(config: {
+    usePreviousYear?: boolean;
+    usePreviousPeriod?: boolean;
+}): boolean {
+    return config.usePreviousYear ?? config.usePreviousPeriod ?? false;
+}

--- a/src/data/common/__tests__/DefaultConfigDatastore.spec.ts
+++ b/src/data/common/__tests__/DefaultConfigDatastore.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { readUsePreviousPeriod } from "$/data/common/DefaultConfigDatastore";
+
+describe("readUsePreviousPeriod (deprecated key retro-compatibility)", () => {
+    it("honors the legacy usePreviousYear key when present", () => {
+        expect(readUsePreviousPeriod({ usePreviousYear: true })).toBe(true);
+    });
+
+    it("prioritizes usePreviousYear over usePreviousPeriod when both are present", () => {
+        expect(readUsePreviousPeriod({ usePreviousYear: true, usePreviousPeriod: false })).toBe(
+            true
+        );
+    });
+
+    it("falls back to usePreviousPeriod when the legacy key is absent", () => {
+        expect(readUsePreviousPeriod({ usePreviousPeriod: true })).toBe(true);
+    });
+
+    it("defaults to false when neither key is present", () => {
+        expect(readUsePreviousPeriod({})).toBe(false);
+    });
+});

--- a/src/data/repositories/DataQualityIssuesProgramConfigD2Repository.ts
+++ b/src/data/repositories/DataQualityIssuesProgramConfigD2Repository.ts
@@ -7,6 +7,7 @@ import {
 import { apiToFuture, FutureData } from "$/data/api-futures";
 import { Future } from "$/domain/entities/generic/Future";
 import { DataQualityIssuesProgramConfig } from "$/domain/entities/DataQualityIssuesProgramConfig";
+import { QualityAnalysis } from "$/domain/entities/QualityAnalysis";
 import { Code } from "$/domain/entities/Ref";
 import {
     buildProgramConfigByProgramCode,
@@ -375,8 +376,8 @@ export class DataQualityIssuesProgramConfigD2Repository
             const raw = settings.defaultConfig;
             return Future.success({
                 dataSet: raw.dataSet,
-                startDate: raw.startDate,
-                endDate: raw.endDate,
+                startDate: QualityAnalysis.normalizePeriodBoundary(raw.startDate, "start"),
+                endDate: QualityAnalysis.normalizePeriodBoundary(raw.endDate, "end"),
                 orgUnits: raw.orgUnits,
                 usePreviousPeriod: readUsePreviousPeriod(raw),
             });

--- a/src/data/repositories/DataQualityIssuesProgramConfigD2Repository.ts
+++ b/src/data/repositories/DataQualityIssuesProgramConfigD2Repository.ts
@@ -13,6 +13,10 @@ import {
     DatastoreProgramConfig,
 } from "$/data/repositories/entities/DatastoreProgramConfig";
 import { DATA_QUALITY_NAMESPACE, dataStoreKeys } from "$/data/common/DataStoreConfig";
+import {
+    DefaultConfigDatastore,
+    readUsePreviousPeriod,
+} from "$/data/common/DefaultConfigDatastore";
 import { DataStore } from "@eyeseetea/d2-api/api";
 import {
     mapStepsDatastoreToStepSettings,
@@ -170,12 +174,24 @@ export class DataQualityIssuesProgramConfigD2Repository
     ): boolean {
         const expectedTEAs: Code[] = Object.values(datastoreProgramConfig.trackedEntityAttributes);
 
-        const actualTEAs = new Set(
-            (programTrackedEntityAttributes ?? []).map(p => p.trackedEntityAttribute.code)
+        const actualTEAsByCode = new Map(
+            (programTrackedEntityAttributes ?? []).map(p => [
+                p.trackedEntityAttribute.code,
+                p.trackedEntityAttribute,
+            ])
         );
-        const missingTEAs = expectedTEAs.filter(code => !actualTEAs.has(code));
+        const missingTEAs = expectedTEAs.filter(code => !actualTEAsByCode.has(code));
 
-        return missingTEAs.length === 0;
+        const dateTEACodes = [
+            datastoreProgramConfig.trackedEntityAttributes.startDate,
+            datastoreProgramConfig.trackedEntityAttributes.endDate,
+        ];
+        const wrongValueTypeTEAs = dateTEACodes.filter(code => {
+            const tea = actualTEAsByCode.get(code);
+            return tea !== undefined && tea.valueType !== "DATE";
+        });
+
+        return missingTEAs.length === 0 && wrongValueTypeTEAs.length === 0;
     }
 
     private checkProgramStages(
@@ -349,16 +365,21 @@ export class DataQualityIssuesProgramConfigD2Repository
         programCode: Code
     ): FutureData<DataQualityIssuesProgramConfig["defaultSettings"]> {
         return apiToFuture(
-            dataStore.get<{ defaultConfig: DataQualityIssuesProgramConfig["defaultSettings"] }>(
-                `settings-${programCode}`
-            )
+            dataStore.get<{ defaultConfig: DefaultConfigDatastore }>(`settings-${programCode}`)
         ).flatMap(settings => {
             if (!settings) {
                 return Future.error(
                     new Error(`No settings found for program code: ${programCode}`)
                 );
             }
-            return Future.success(settings.defaultConfig);
+            const raw = settings.defaultConfig;
+            return Future.success({
+                dataSet: raw.dataSet,
+                startDate: raw.startDate,
+                endDate: raw.endDate,
+                orgUnits: raw.orgUnits,
+                usePreviousPeriod: readUsePreviousPeriod(raw),
+            });
         });
     }
 
@@ -384,6 +405,7 @@ const programFields = {
     programTrackedEntityAttributes: {
         trackedEntityAttribute: {
             code: true,
+            valueType: true,
         },
     },
     trackedEntityType: {

--- a/src/data/repositories/DataQualityIssuesProgramConfigTestRepository.ts
+++ b/src/data/repositories/DataQualityIssuesProgramConfigTestRepository.ts
@@ -24,7 +24,7 @@ export class DataQualityIssuesProgramConfigTestRepository
                     startDate: "2023-01-01",
                     endDate: "2023-12-31",
                     orgUnits: [],
-                    usePreviousYear: false,
+                    usePreviousPeriod: false,
                 },
                 steps: [],
             }).get()

--- a/src/data/repositories/MetadataD2Repository.ts
+++ b/src/data/repositories/MetadataD2Repository.ts
@@ -14,7 +14,7 @@ const METADATA_FIELDS = {
         fields: { id: true, name: true, code: true },
     },
     dataSets: {
-        fields: { id: true, name: true, code: true },
+        fields: { id: true, name: true, code: true, periodType: true },
     },
     trackedEntityAttributes: {
         fields: { id: true, name: true, code: true },

--- a/src/data/repositories/ModuleD2Repository.ts
+++ b/src/data/repositories/ModuleD2Repository.ts
@@ -26,6 +26,7 @@ export class ModuleD2Repository implements ModuleRepository {
                     id: true,
                     displayName: true,
                     code: true,
+                    periodType: true,
                     sections: {
                         id: true,
                         dataElements: { id: true },
@@ -78,6 +79,7 @@ export class ModuleD2Repository implements ModuleRepository {
                     id: d2DataSet.id,
                     code: d2DataSet.code,
                     name: d2DataSet.displayName,
+                    periodType: d2DataSet.periodType,
                     dataElements: _(d2DataSet.dataSetElements)
                         .map((d2DataSetElement): Maybe<DataElement> => {
                             if (!sectionDataElements.includes(d2DataSetElement.dataElement.id))
@@ -125,6 +127,7 @@ export class ModuleD2Repository implements ModuleRepository {
                         id: d2DataSet.id,
                         code: d2DataSet.code,
                         name: d2DataSet.displayName,
+                        periodType: d2DataSet.periodType,
                     };
                 });
         });
@@ -156,6 +159,7 @@ export class ModuleD2Repository implements ModuleRepository {
                         id: d2DataSet.id,
                         code: d2DataSet.code,
                         name: d2DataSet.displayName,
+                        periodType: d2DataSet.periodType,
                     };
                 });
 
@@ -244,6 +248,7 @@ const dataSetFields = {
     id: true,
     displayName: true,
     code: true,
+    periodType: true,
 } as const;
 
 type D2DataSet = MetadataPick<{

--- a/src/data/repositories/ModuleTestRepository.ts
+++ b/src/data/repositories/ModuleTestRepository.ts
@@ -8,12 +8,31 @@ import {
 } from "$/domain/repositories/ModuleRepository";
 import { FutureData } from "$/data/api-futures";
 
+const testModules: Module[] = [
+    {
+        id: "module-monthly",
+        code: "MONTHLY",
+        name: "Monthly Module",
+        periodType: "Monthly",
+        dataElements: [],
+        disaggregations: [],
+    },
+    {
+        id: "module-yearly",
+        code: "YEARLY",
+        name: "Yearly Module",
+        periodType: "Yearly",
+        dataElements: [],
+        disaggregations: [],
+    },
+];
+
 export class ModuleTestRepository implements ModuleRepository {
     getByIds(): FutureData<Module[]> {
-        return Future.success([]);
+        return Future.success(testModules);
     }
     get(): FutureData<Module[]> {
-        return Future.success([]);
+        return Future.success(testModules);
     }
 
     getAllBase(_options?: ModulesSortingFilterOptions): FutureData<ModuleBase[]> {

--- a/src/data/repositories/QualityAnalysisD2Repository.ts
+++ b/src/data/repositories/QualityAnalysisD2Repository.ts
@@ -113,6 +113,7 @@ export class QualityAnalysisD2Repository implements QualityAnalysisRepository {
                 name: undefined,
                 startDate: undefined,
                 status: undefined,
+                periodType: undefined,
             },
             pagination: {
                 page: 1,
@@ -434,7 +435,7 @@ export class QualityAnalysisD2Repository implements QualityAnalysisRepository {
             },
             {
                 attribute: metadata.trackedEntityAttributes.endDate.id,
-                value: qualityAnalysis.endDate,
+                value: QualityAnalysis.normalizePeriodBoundary(qualityAnalysis.endDate, "end"),
             },
             {
                 attribute: metadata.trackedEntityAttributes.module.id,
@@ -442,7 +443,7 @@ export class QualityAnalysisD2Repository implements QualityAnalysisRepository {
             },
             {
                 attribute: metadata.trackedEntityAttributes.startDate.id,
-                value: qualityAnalysis.startDate,
+                value: QualityAnalysis.normalizePeriodBoundary(qualityAnalysis.startDate, "start"),
             },
             {
                 attribute: metadata.trackedEntityAttributes.status.id,
@@ -595,12 +596,23 @@ export class QualityAnalysisD2Repository implements QualityAnalysisRepository {
             ? `${metadata.trackedEntityAttributes.name.id}:LIKE:${filters.name}`
             : undefined;
 
-        const startDateFilter = filters.startDate
-            ? `${metadata.trackedEntityAttributes.startDate.id}:EQ:${filters.startDate}`
+        // Overlap filter: startDate <= window end AND endDate >= window start. A legacy
+        // bare-year endDate ("2024") sorts *before* any full ISO date in that same year,
+        // so a precise `GE` would wrongly exclude it — coarsen to year granularity, but
+        // only for `Yearly`/unknown periodType, the only ones with legacy bare-year data.
+        const canHaveLegacyYearData = !filters.periodType || filters.periodType === "Yearly";
+
+        const endDateLowerBound =
+            canHaveLegacyYearData && filters.startDate
+                ? filters.startDate.slice(0, 4)
+                : filters.startDate;
+
+        const startDateFilter = filters.endDate
+            ? `${metadata.trackedEntityAttributes.startDate.id}:LE:${filters.endDate}`
             : undefined;
 
-        const endDateFilter = filters.endDate
-            ? `${metadata.trackedEntityAttributes.endDate.id}:EQ:${filters.endDate}`
+        const endDateFilter = endDateLowerBound
+            ? `${metadata.trackedEntityAttributes.endDate.id}:GE:${endDateLowerBound}`
             : undefined;
 
         const moduleFilter = filters.module
@@ -688,13 +700,23 @@ export class QualityAnalysisD2Repository implements QualityAnalysisRepository {
             name: this.getValueOrDefault(
                 attributesById.get(this.getIdOrThrow(metadata.trackedEntityAttributes.name.id))
             ),
-            endDate: this.getValueOrDefault(
-                attributesById.get(this.getIdOrThrow(metadata.trackedEntityAttributes.endDate.id))
+            endDate: QualityAnalysis.normalizePeriodBoundary(
+                this.getValueOrDefault(
+                    attributesById.get(
+                        this.getIdOrThrow(metadata.trackedEntityAttributes.endDate.id)
+                    )
+                ),
+                "end"
             ),
             sections: sections,
             module: module,
-            startDate: this.getValueOrDefault(
-                attributesById.get(this.getIdOrThrow(metadata.trackedEntityAttributes.startDate.id))
+            startDate: QualityAnalysis.normalizePeriodBoundary(
+                this.getValueOrDefault(
+                    attributesById.get(
+                        this.getIdOrThrow(metadata.trackedEntityAttributes.startDate.id)
+                    )
+                ),
+                "start"
             ),
             status: status,
             lastModification: this.getValueOrDefault(

--- a/src/data/repositories/QualityAnalysisD2Repository.ts
+++ b/src/data/repositories/QualityAnalysisD2Repository.ts
@@ -592,42 +592,13 @@ export class QualityAnalysisD2Repository implements QualityAnalysisRepository {
         filters: QualityAnalysisOptions["filters"],
         metadata: MetadataItem
     ): Maybe<string[]> {
-        const nameFilter = filters.name
-            ? `${metadata.trackedEntityAttributes.name.id}:LIKE:${filters.name}`
-            : undefined;
-
-        // Overlap filter: startDate <= window end AND endDate >= window start. A legacy
-        // bare-year endDate ("2024") sorts *before* any full ISO date in that same year,
-        // so a precise `GE` would wrongly exclude it — coarsen to year granularity, but
-        // only for `Yearly`/unknown periodType, the only ones with legacy bare-year data.
-        const canHaveLegacyYearData = !filters.periodType || filters.periodType === "Yearly";
-
-        const endDateLowerBound =
-            canHaveLegacyYearData && filters.startDate
-                ? filters.startDate.slice(0, 4)
-                : filters.startDate;
-
-        const startDateFilter = filters.endDate
-            ? `${metadata.trackedEntityAttributes.startDate.id}:LE:${filters.endDate}`
-            : undefined;
-
-        const endDateFilter = endDateLowerBound
-            ? `${metadata.trackedEntityAttributes.endDate.id}:GE:${endDateLowerBound}`
-            : undefined;
-
-        const moduleFilter = filters.module
-            ? `${metadata.trackedEntityAttributes.module.id}:EQ:${filters.module}`
-            : undefined;
-
-        const status = filters.status
-            ? `${metadata.trackedEntityAttributes.status.id}:EQ:${filters.status}`
-            : undefined;
-
-        const allFilters = _([endDateFilter, moduleFilter, nameFilter, startDateFilter, status])
-            .compact()
-            .value();
-
-        return allFilters.length > 0 ? allFilters : undefined;
+        return buildAnalysisFilters(filters, {
+            name: metadata.trackedEntityAttributes.name.id,
+            startDate: metadata.trackedEntityAttributes.startDate.id,
+            endDate: metadata.trackedEntityAttributes.endDate.id,
+            module: metadata.trackedEntityAttributes.module.id,
+            status: metadata.trackedEntityAttributes.status.id,
+        });
     }
 
     private buildOrder(
@@ -781,3 +752,54 @@ export class QualityAnalysisD2Repository implements QualityAnalysisRepository {
 type D2AnalysisDataStore = { sections: SectionInfo[] };
 type SectionInfo = { id: Id; status: string };
 type AnalysisSectionStatus = { id: Id; extraInfo: Maybe<SectionInfo[]> };
+
+type AnalysisFilterTeaIds = {
+    name: Id;
+    startDate: Id;
+    endDate: Id;
+    module: Id;
+    status: Id;
+};
+
+/**
+ * Builds the tracker `filter` clauses for the dashboard analyses query. Start/End
+ * are a periodicity-aware overlap window: an analysis matches when its own
+ * `startDate <= window end` AND `endDate >= window start` (each term emitted only when
+ * that bound is set, giving a half-open filter for a single bound). A legacy bare-year
+ * `endDate` ("2024") sorts *before* any full ISO date in that same year, so a precise
+ * `:GE:` would wrongly exclude it — the `:GE:` lower bound is therefore coarsened to
+ * year granularity, but only for `Yearly`/unknown periodType, the only ones that ever
+ * stored bare-year boundaries. Extracted as a pure function so it can be unit-tested
+ * without a live `D2Api`.
+ */
+export function buildAnalysisFilters(
+    filters: QualityAnalysisOptions["filters"],
+    teaIds: AnalysisFilterTeaIds
+): Maybe<string[]> {
+    const nameFilter = filters.name ? `${teaIds.name}:LIKE:${filters.name}` : undefined;
+
+    const canHaveLegacyYearData = !filters.periodType || filters.periodType === "Yearly";
+
+    const endDateLowerBound =
+        canHaveLegacyYearData && filters.startDate
+            ? filters.startDate.slice(0, 4)
+            : filters.startDate;
+
+    const startDateFilter = filters.endDate
+        ? `${teaIds.startDate}:LE:${filters.endDate}`
+        : undefined;
+
+    const endDateFilter = endDateLowerBound
+        ? `${teaIds.endDate}:GE:${endDateLowerBound}`
+        : undefined;
+
+    const moduleFilter = filters.module ? `${teaIds.module}:EQ:${filters.module}` : undefined;
+
+    const status = filters.status ? `${teaIds.status}:EQ:${filters.status}` : undefined;
+
+    const allFilters = _([endDateFilter, moduleFilter, nameFilter, startDateFilter, status])
+        .compact()
+        .value();
+
+    return allFilters.length > 0 ? allFilters : undefined;
+}

--- a/src/data/repositories/SettingsD2Repository.ts
+++ b/src/data/repositories/SettingsD2Repository.ts
@@ -1,5 +1,6 @@
 import _ from "$/domain/entities/generic/Collection";
 import { D2Api } from "$/types/d2-api";
+import { QualityAnalysis } from "$/domain/entities/QualityAnalysis";
 import { Settings } from "$/domain/entities/Settings";
 import { SettingsRepository } from "$/domain/repositories/SettingsRepository";
 import { FutureData, apiToFuture } from "$/data/api-futures";
@@ -28,10 +29,16 @@ export class SettingsD2Repository implements SettingsRepository {
 
             return this.getDataSet(d2Response.defaultConfig.dataSet).map(dataSet => {
                 return Settings.build({
-                    endDate: d2Response.defaultConfig.endDate,
+                    endDate: QualityAnalysis.normalizePeriodBoundary(
+                        d2Response.defaultConfig.endDate,
+                        "end"
+                    ),
                     module: dataSet,
                     countryIds: d2Response.defaultConfig.orgUnits,
-                    startDate: d2Response.defaultConfig.startDate,
+                    startDate: QualityAnalysis.normalizePeriodBoundary(
+                        d2Response.defaultConfig.startDate,
+                        "start"
+                    ),
                     usePreviousPeriod: readUsePreviousPeriod(d2Response.defaultConfig),
                 }).get();
             });

--- a/src/data/repositories/SettingsD2Repository.ts
+++ b/src/data/repositories/SettingsD2Repository.ts
@@ -3,9 +3,13 @@ import { D2Api } from "$/types/d2-api";
 import { Settings } from "$/domain/entities/Settings";
 import { SettingsRepository } from "$/domain/repositories/SettingsRepository";
 import { FutureData, apiToFuture } from "$/data/api-futures";
-import { Code, Id, NamedCodeRef } from "$/domain/entities/Ref";
+import { Code, NamedCodeRef } from "$/domain/entities/Ref";
 import { DATA_QUALITY_NAMESPACE } from "$/data/common/DataStoreConfig";
 import { Future } from "$/domain/entities/generic/Future";
+import {
+    DefaultConfigDatastore,
+    readUsePreviousPeriod,
+} from "$/data/common/DefaultConfigDatastore";
 
 export class SettingsD2Repository implements SettingsRepository {
     constructor(private api: D2Api) {}
@@ -28,16 +32,16 @@ export class SettingsD2Repository implements SettingsRepository {
                     module: dataSet,
                     countryIds: d2Response.defaultConfig.orgUnits,
                     startDate: d2Response.defaultConfig.startDate,
-                    usePreviousYear: d2Response.defaultConfig.usePreviousYear,
+                    usePreviousPeriod: readUsePreviousPeriod(d2Response.defaultConfig),
                 }).get();
             });
         });
     }
 
-    private getDataSet(dataSetCode: string): FutureData<NamedCodeRef> {
+    private getDataSet(dataSetCode: string): FutureData<NamedCodeRef & { periodType: string }> {
         return apiToFuture(
             this.api.models.dataSets.get({
-                fields: { id: true, code: true, name: true },
+                fields: { id: true, code: true, name: true, periodType: true },
                 filter: { code: { eq: dataSetCode } },
             })
         ).flatMap(d2Response => {
@@ -50,8 +54,5 @@ export class SettingsD2Repository implements SettingsRepository {
 }
 
 type D2DataStore = {
-    defaultConfig: Pick<Settings, "endDate" | "startDate" | "usePreviousYear"> & {
-        dataSet: string;
-        orgUnits: Id[];
-    };
+    defaultConfig: DefaultConfigDatastore;
 };

--- a/src/data/repositories/__tests__/QualityAnalysisD2Repository.spec.ts
+++ b/src/data/repositories/__tests__/QualityAnalysisD2Repository.spec.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { buildAnalysisFilters } from "$/data/repositories/QualityAnalysisD2Repository";
+import { QualityAnalysisOptions } from "$/domain/repositories/QualityAnalysisRepository";
+
+const teaIds = {
+    name: "teaName",
+    startDate: "teaStart",
+    endDate: "teaEnd",
+    module: "teaModule",
+    status: "teaStatus",
+};
+
+type Filters = QualityAnalysisOptions["filters"];
+
+const emptyFilters: Filters = {
+    endDate: undefined,
+    module: undefined,
+    name: undefined,
+    startDate: undefined,
+    status: undefined,
+    ids: undefined,
+    periodType: undefined,
+};
+
+function buildFilters(overrides: Partial<Filters>): ReturnType<typeof buildAnalysisFilters> {
+    return buildAnalysisFilters({ ...emptyFilters, ...overrides }, teaIds);
+}
+
+describe("buildAnalysisFilters (dashboard overlap query)", () => {
+    describe("periodicity-aware overlap window", () => {
+        it("emits both overlap bounds for a Monthly window at full ISO precision", () => {
+            const result = buildFilters({
+                periodType: "Monthly",
+                startDate: "2024-03-01",
+                endDate: "2024-09-30",
+            });
+
+            expect(result).toEqual(["teaEnd:GE:2024-03-01", "teaStart:LE:2024-09-30"]);
+        });
+
+        it("coarsens the endDate lower bound to year granularity for a Yearly window (legacy safety)", () => {
+            const result = buildFilters({
+                periodType: "Yearly",
+                startDate: "2024-03-01",
+                endDate: "2024-09-30",
+            });
+
+            expect(result).toEqual(["teaEnd:GE:2024", "teaStart:LE:2024-09-30"]);
+        });
+
+        it("coarsens the endDate lower bound when the periodType could not be resolved", () => {
+            const result = buildFilters({
+                periodType: undefined,
+                startDate: "2024-03-01",
+                endDate: "2024-09-30",
+            });
+
+            expect(result).toEqual(["teaEnd:GE:2024", "teaStart:LE:2024-09-30"]);
+        });
+    });
+
+    describe("half-open windows (single bound)", () => {
+        it("emits only the lower bound when just the start bound is set (Monthly, no coarsening)", () => {
+            const result = buildFilters({ periodType: "Monthly", startDate: "2024-03-01" });
+
+            expect(result).toEqual(["teaEnd:GE:2024-03-01"]);
+        });
+
+        it("coarsens the lower bound to a year when just the start bound is set (Yearly)", () => {
+            const result = buildFilters({ periodType: "Yearly", startDate: "2024-03-01" });
+
+            expect(result).toEqual(["teaEnd:GE:2024"]);
+        });
+
+        it("emits only the upper bound when just the end bound is set", () => {
+            const result = buildFilters({ periodType: "Yearly", endDate: "2024-09-30" });
+
+            expect(result).toEqual(["teaStart:LE:2024-09-30"]);
+        });
+    });
+
+    describe("other filter terms", () => {
+        it("combines name, module and status terms in a stable order", () => {
+            const result = buildFilters({
+                periodType: "Monthly",
+                startDate: "2024-03-01",
+                endDate: "2024-09-30",
+                name: "issue",
+                module: "moduleId",
+                status: "In Progress",
+            });
+
+            expect(result).toEqual([
+                "teaEnd:GE:2024-03-01",
+                "teaModule:EQ:moduleId",
+                "teaName:LIKE:issue",
+                "teaStart:LE:2024-09-30",
+                "teaStatus:EQ:In Progress",
+            ]);
+        });
+
+        it("returns undefined when no filter is set", () => {
+            expect(buildFilters({})).toBeUndefined();
+        });
+    });
+});

--- a/src/domain/entities/DataQualityIssuesProgramConfig.ts
+++ b/src/domain/entities/DataQualityIssuesProgramConfig.ts
@@ -5,18 +5,20 @@ import {
     validateDateRange,
     validateMustBeEmpty,
     validateRequired,
+    validateSamePeriodType,
 } from "$/domain/entities/generic/validations";
 import { Code, Id } from "$/domain/entities/Ref";
 import { StepSettings } from "$/domain/entities/StepSettings";
 
-interface DataQualityIssuesProgramConfigAttrs {
+export interface DataQualityIssuesProgramConfigAttrs {
     selectedProgramCode: Code;
     selectedModuleCodes: Code[];
+    selectedModulePeriodTypes?: string[];
     defaultSettings: {
         dataSet: Code;
         startDate: string;
         endDate: string;
-        usePreviousYear: boolean;
+        usePreviousPeriod: boolean;
         orgUnits: Id[];
     };
     steps: StepSettings[];
@@ -29,7 +31,7 @@ export class DataQualityIssuesProgramConfig extends Struct<DataQualityIssuesProg
         const config = new DataQualityIssuesProgramConfig(attrs);
         const ds = config.defaultSettings;
 
-        const dateErrors = ds?.usePreviousYear
+        const dateErrors = ds?.usePreviousPeriod
             ? [
                   {
                       property: "defaultSettings" as const,
@@ -88,6 +90,12 @@ export class DataQualityIssuesProgramConfig extends Struct<DataQualityIssuesProg
                 errors: validateRequired(config.steps),
                 value: config.steps,
                 fieldName: "steps configuration",
+            },
+            {
+                property: "selectedModuleCodes" as const,
+                errors: validateSamePeriodType(config.selectedModulePeriodTypes ?? []),
+                value: config.selectedModulePeriodTypes,
+                fieldName: "selected datasets periodicity",
             },
             ...dateErrors,
         ].filter(validation => validation.errors.length > 0);

--- a/src/domain/entities/MetadataItem.ts
+++ b/src/domain/entities/MetadataItem.ts
@@ -1,4 +1,5 @@
 import { Maybe } from "$/utils/ts-utils";
+import { PeriodType } from "./PeriodType";
 import { Id, NamedCodeRef, Ref } from "./Ref";
 
 export interface OptionSet extends NamedCodeRef {
@@ -14,7 +15,7 @@ export interface ProgramStage extends NamedCodeRef {
 export interface MetadataItem {
     trackedEntityTypes: { dataQuality: NamedCodeRef };
     organisationUnits: { global: NamedCodeRef };
-    dataSets: NamedCodeRef[];
+    dataSets: Array<NamedCodeRef & { periodType: PeriodType }>;
     optionSets: { action: OptionSet; status: OptionSet };
     trackedEntityAttributes: {
         endDate: NamedCodeRef;

--- a/src/domain/entities/Module.ts
+++ b/src/domain/entities/Module.ts
@@ -1,4 +1,5 @@
 import { DataElement } from "./DataElement";
+import { PeriodType } from "./PeriodType";
 import { NamedCodeRef, NamedRef } from "./Ref";
 
 type ModuleExtra = {
@@ -6,6 +7,8 @@ type ModuleExtra = {
     disaggregations: NamedRef[];
 };
 
-export type ModuleBase = NamedCodeRef;
+export type ModuleBase = NamedCodeRef & {
+    periodType: PeriodType;
+};
 
 export type Module = ModuleBase & ModuleExtra;

--- a/src/domain/entities/Period.ts
+++ b/src/domain/entities/Period.ts
@@ -254,12 +254,15 @@ function generateFinancialPeriods(
     if (startMonthIndex === undefined)
         return steppedPeriods(start, end, 1, "days", m => m.format("YYYYMMDD"));
 
-    return _(Collection.range(start.year(), end.year() + 1).value())
+    // Start one year early so a financial year that begins in the previous calendar
+    // year but extends into the range (e.g. FinancialApril 2023 spanning Apr 2023 – Mar
+    // 2024 when the range starts in Feb 2024) is still considered.
+    return _(Collection.range(start.year() - 1, end.year() + 1).value())
         .compactMap(year => {
             const periodStart = dateFromParts({ year: year, month: startMonthIndex, date: 1 });
             const periodEnd = periodStart.clone().add(1, "year").subtract(1, "day");
-            const isContained = periodStart.isSameOrAfter(start) && periodEnd.isSameOrBefore(end);
-            return isContained ? `${year}${monthName}` : undefined;
+            const intersects = periodStart.isSameOrBefore(end) && periodEnd.isSameOrAfter(start);
+            return intersects ? `${year}${monthName}` : undefined;
         })
         .value();
 }

--- a/src/domain/entities/Period.ts
+++ b/src/domain/entities/Period.ts
@@ -1,0 +1,365 @@
+import _, { Collection } from "$/domain/entities/generic/Collection";
+import {
+    DateDiffUnit,
+    DateDurationUnit,
+    DateTime,
+    dateFromJsDate,
+    dateFromParts,
+    parseDate,
+} from "$/utils/dates";
+import { DateISOString, Period } from "./Ref";
+import { PeriodType } from "./PeriodType";
+
+const ISO_DATE = "YYYY-MM-DD";
+
+const weeklyStartDay: Record<string, number> = {
+    Weekly: 1,
+    WeeklyWednesday: 3,
+    WeeklyThursday: 4,
+    WeeklySaturday: 6,
+    WeeklySunday: 0,
+};
+
+const financialMonthByName: Record<string, number> = { April: 3, July: 6, Oct: 9, Nov: 10 };
+
+/** Returns every DHIS2 period ID whose period intersects the `[startIso, endIso]` range. */
+export function getPeriodsForRange(
+    periodType: PeriodType,
+    startIso: DateISOString,
+    endIso: DateISOString
+): ReadonlyArray<Period> {
+    if (!startIso || !endIso) return [];
+    const start = parseDate(startIso, ISO_DATE);
+    const end = parseDate(endIso, ISO_DATE);
+    if (!start.isValid() || !end.isValid() || start.isAfter(end)) return [];
+    return generatePeriods(periodType, start, end);
+}
+
+/** `getPeriodsForRange` mapped to `{ value, text }` options for the period multi-selects. */
+export function getPeriodOptionsForRange(
+    periodType: PeriodType,
+    startIso: DateISOString,
+    endIso: DateISOString
+): ReadonlyArray<{ value: string; text: string }> {
+    return getPeriodsForRange(periodType, startIso, endIso).map(id => ({
+        value: id,
+        text: getPeriodLabel(periodType, id),
+    }));
+}
+
+/** Human-readable label for a DHIS2 period ID; falls back to the raw id for uncommon types. */
+export function getPeriodLabel(periodType: PeriodType, periodId: Period): string {
+    switch (periodType) {
+        case "Yearly":
+            return periodId;
+        case "Monthly": {
+            const parsed = parseDate(periodId, "YYYYMM", true);
+            return parsed.isValid() ? parsed.format("MMMM YYYY") : periodId;
+        }
+        case "Daily": {
+            const parsed = parseDate(periodId, "YYYYMMDD", true);
+            return parsed.isValid() ? parsed.format("DD MMM YYYY") : periodId;
+        }
+        case "Quarterly": {
+            const match = /^(\d{4})Q([1-4])$/.exec(periodId);
+            return match ? `Q${match[2]} ${match[1]}` : periodId;
+        }
+        default:
+            return periodId;
+    }
+}
+
+/** ISO boundaries of the period immediately preceding `reference`, for any periodicity. */
+export function getPreviousPeriod(
+    periodType: PeriodType,
+    reference: Date = new Date()
+): { startDate: DateISOString; endDate: DateISOString } {
+    const ref = dateFromJsDate(reference);
+    const currentStart = currentPeriodStart(periodType, ref);
+    const step = periodStep(periodType);
+    const previousStart = currentStart.clone().subtract(step.amount, step.unit);
+    const previousEnd = currentStart.clone().subtract(1, "day");
+    return {
+        startDate: previousStart.format(ISO_DATE),
+        endDate: previousEnd.format(ISO_DATE),
+    };
+}
+
+type StepUnit = DateDiffUnit;
+
+function generatePeriods(periodType: PeriodType, start: DateTime, end: DateTime): string[] {
+    switch (periodType) {
+        case "Daily":
+            return steppedPeriods(start, end, 1, "days", m => m.format("YYYYMMDD"));
+        case "Monthly":
+            return steppedPeriods(start, end, 1, "months", m => m.format("YYYYMM"));
+        case "Yearly":
+            return steppedPeriods(start, end, 1, "years", m => m.format("YYYY"));
+        case "Quarterly":
+            return steppedPeriods(start, end, 1, "quarters", m => m.format("YYYY[Q]Q"));
+        case "Weekly":
+        case "WeeklyWednesday":
+        case "WeeklyThursday":
+        case "WeeklySaturday":
+        case "WeeklySunday":
+            return generateWeeklyPeriods(periodType, start, end);
+        case "BiWeekly":
+            return generateBiWeeklyPeriods(start, end);
+        case "BiMonthly":
+            return generateBiMonthlyPeriods(start, end);
+        case "QuarterlyNov":
+            return generateQuarterlyNovPeriods(start, end);
+        case "SixMonthly":
+            return generateSixMonthlyPeriods(start, end);
+        case "SixMonthlyApril":
+            return generateSixMonthlyAprilPeriods(start, end);
+        case "SixMonthlyNov":
+            return generateSixMonthlyNovPeriods(start, end);
+        case "FinancialApril":
+        case "FinancialJuly":
+        case "FinancialOct":
+        case "FinancialNov":
+            return generateFinancialPeriods(start, end, periodType);
+        default:
+            // Non-throwing graceful fallback for unrecognized/future period types.
+            return steppedPeriods(start, end, 1, "days", m => m.format("YYYYMMDD"));
+    }
+}
+
+/** Moments from `alignedStart`, stepping by `amount` `unit`, up to and including `end`. */
+function steppedMoments(
+    alignedStart: DateTime,
+    end: DateTime,
+    amount: number,
+    unit: StepUnit
+): DateTime[] {
+    if (alignedStart.isAfter(end)) return [];
+    const span = Math.max(0, end.diff(alignedStart, unit));
+    const maxIndex = Math.floor(span / amount) + 1;
+    return Collection.range(0, maxIndex + 1)
+        .map(index => alignedStart.clone().add(index * amount, unit))
+        .select(current => current.isSameOrBefore(end))
+        .value();
+}
+
+function steppedPeriods(
+    alignedStart: DateTime,
+    end: DateTime,
+    amount: number,
+    unit: StepUnit,
+    format: (current: DateTime) => string
+): string[] {
+    return steppedMoments(alignedStart, end, amount, unit).map(format);
+}
+
+function generateWeeklyPeriods(periodType: PeriodType, start: DateTime, end: DateTime): string[] {
+    const startDay = weeklyStartDay[periodType] ?? 1;
+    const suffix =
+        periodType === "Weekly" ? "W" : `${periodType.replace("Weekly", "").substring(0, 3)}W`;
+
+    const aligned = start.clone().isoWeekday(startDay);
+    const weeklyStart = aligned.isAfter(start) ? aligned.clone().subtract(1, "week") : aligned;
+
+    return steppedPeriods(
+        weeklyStart,
+        end,
+        1,
+        "weeks",
+        current => `${current.isoWeekYear()}${suffix}${current.isoWeek()}`
+    );
+}
+
+function getBiWeekStart(reference: DateTime): DateTime {
+    const isoWeek = reference.isoWeek();
+    const startWeek = isoWeek % 2 === 0 ? isoWeek - 1 : isoWeek;
+    return reference
+        .clone()
+        .isoWeekYear(reference.isoWeekYear())
+        .isoWeek(startWeek)
+        .startOf("isoWeek");
+}
+
+function generateBiWeeklyPeriods(start: DateTime, end: DateTime): string[] {
+    return steppedPeriods(getBiWeekStart(start), end, 2, "weeks", current => {
+        const biWeekNum = Math.ceil(current.isoWeek() / 2);
+        return `${current.isoWeekYear()}BiW${biWeekNum}`;
+    });
+}
+
+function generateBiMonthlyPeriods(start: DateTime, end: DateTime): string[] {
+    const startMonth = Math.floor(start.month() / 2) * 2;
+    const alignedStart = start.clone().month(startMonth).startOf("month");
+    return steppedPeriods(alignedStart, end, 2, "months", current => {
+        const biMonthNum = Math.floor(current.month() / 2) + 1;
+        return `${current.year()}${String(biMonthNum).padStart(2, "0")}B`;
+    });
+}
+
+function generateQuarterlyNovPeriods(start: DateTime, end: DateTime): string[] {
+    const alignedStart = start.clone().add(2, "months").startOf("quarter").subtract(2, "months");
+    return steppedPeriods(alignedStart, end, 3, "months", current => {
+        const year = current.year();
+        if (current.month() >= 10) return `${year + 1}NovQ1`;
+        const quarter = Math.floor((current.month() + 2) / 3) + 1;
+        return `${year}NovQ${quarter}`;
+    });
+}
+
+function generateSixMonthlyPeriods(start: DateTime, end: DateTime): string[] {
+    const startMonth = start.month() < 6 ? 0 : 6;
+    const alignedStart = start.clone().month(startMonth).startOf("month");
+    return steppedPeriods(alignedStart, end, 6, "months", current => {
+        const half = current.month() < 6 ? 1 : 2;
+        return `${current.year()}S${half}`;
+    });
+}
+
+function generateSixMonthlyAprilPeriods(start: DateTime, end: DateTime): string[] {
+    const year = start.month() >= 3 ? start.year() : start.year() - 1;
+    const alignedStart = dateFromParts({ year: year, month: 3, date: 1 });
+    return _(steppedMoments(alignedStart, end, 6, "months"))
+        .compactMap(current => {
+            const periodEnd = current.clone().add(6, "months").subtract(1, "day");
+            if (!periodEnd.isSameOrAfter(start)) return undefined;
+            const semester = current.month() === 3 ? 1 : 2;
+            return `${current.year()}AprilS${semester}`;
+        })
+        .value();
+}
+
+function generateSixMonthlyNovPeriods(start: DateTime, end: DateTime): string[] {
+    const alignedStart =
+        start.month() >= 5
+            ? dateFromParts({ year: start.year(), month: 4, date: 1 })
+            : dateFromParts({ year: start.year() - 1, month: 10, date: 1 });
+    return _(steppedMoments(alignedStart, end, 6, "months"))
+        .compactMap(current => {
+            const periodEnd = current.clone().add(6, "months").subtract(1, "day");
+            if (!periodEnd.isSameOrAfter(start)) return undefined;
+            const isNovStart = current.month() === 10;
+            const semester = isNovStart ? 1 : 2;
+            const displayYear = isNovStart ? current.year() + 1 : current.year();
+            return `${displayYear}NovS${semester}`;
+        })
+        .value();
+}
+
+function generateFinancialPeriods(
+    start: DateTime,
+    end: DateTime,
+    periodType: PeriodType
+): string[] {
+    const monthName = periodType.replace("Financial", "");
+    const startMonthIndex = financialMonthByName[monthName];
+    if (startMonthIndex === undefined)
+        return steppedPeriods(start, end, 1, "days", m => m.format("YYYYMMDD"));
+
+    return _(Collection.range(start.year(), end.year() + 1).value())
+        .compactMap(year => {
+            const periodStart = dateFromParts({ year: year, month: startMonthIndex, date: 1 });
+            const periodEnd = periodStart.clone().add(1, "year").subtract(1, "day");
+            const isContained = periodStart.isSameOrAfter(start) && periodEnd.isSameOrBefore(end);
+            return isContained ? `${year}${monthName}` : undefined;
+        })
+        .value();
+}
+
+type PeriodStep = { amount: number; unit: DateDurationUnit };
+
+function periodStep(periodType: PeriodType): PeriodStep {
+    switch (periodType) {
+        case "Daily":
+            return { amount: 1, unit: "days" };
+        case "Weekly":
+        case "WeeklyWednesday":
+        case "WeeklyThursday":
+        case "WeeklySaturday":
+        case "WeeklySunday":
+            return { amount: 1, unit: "weeks" };
+        case "BiWeekly":
+            return { amount: 2, unit: "weeks" };
+        case "Monthly":
+            return { amount: 1, unit: "months" };
+        case "BiMonthly":
+            return { amount: 2, unit: "months" };
+        case "Quarterly":
+        case "QuarterlyNov":
+            return { amount: 3, unit: "months" };
+        case "SixMonthly":
+        case "SixMonthlyApril":
+        case "SixMonthlyNov":
+            return { amount: 6, unit: "months" };
+        case "Yearly":
+        case "FinancialApril":
+        case "FinancialJuly":
+        case "FinancialOct":
+        case "FinancialNov":
+            return { amount: 1, unit: "years" };
+        default:
+            return { amount: 1, unit: "days" };
+    }
+}
+
+function currentPeriodStart(periodType: PeriodType, ref: DateTime): DateTime {
+    switch (periodType) {
+        case "Weekly":
+        case "WeeklyWednesday":
+        case "WeeklyThursday":
+        case "WeeklySaturday":
+        case "WeeklySunday": {
+            const startDay = weeklyStartDay[periodType] ?? 1;
+            const aligned = ref.clone().isoWeekday(startDay);
+            return (aligned.isAfter(ref) ? aligned.subtract(1, "week") : aligned).startOf("day");
+        }
+        case "BiWeekly":
+            return getBiWeekStart(ref);
+        case "Monthly":
+            return ref.clone().startOf("month");
+        case "BiMonthly":
+            return ref
+                .clone()
+                .month(Math.floor(ref.month() / 2) * 2)
+                .startOf("month");
+        case "Quarterly":
+            return ref.clone().startOf("quarter");
+        case "QuarterlyNov": {
+            const anchored = ref.clone().add(2, "months").startOf("quarter").subtract(2, "months");
+            return anchored.isAfter(ref) ? anchored.subtract(3, "months") : anchored;
+        }
+        case "SixMonthly":
+            return ref
+                .clone()
+                .month(ref.month() < 6 ? 0 : 6)
+                .startOf("month");
+        case "SixMonthlyApril": {
+            const year = ref.month() >= 3 ? ref.year() : ref.year() - 1;
+            const firstHalf = dateFromParts({ year: year, month: 3, date: 1 });
+            const secondHalf = firstHalf.clone().add(6, "months");
+            return secondHalf.isSameOrBefore(ref) ? secondHalf : firstHalf;
+        }
+        case "SixMonthlyNov": {
+            const firstHalf =
+                ref.month() >= 5
+                    ? dateFromParts({ year: ref.year(), month: 4, date: 1 })
+                    : dateFromParts({ year: ref.year() - 1, month: 10, date: 1 });
+            const secondHalf = firstHalf.clone().add(6, "months");
+            return secondHalf.isSameOrBefore(ref) ? secondHalf : firstHalf;
+        }
+        case "Yearly":
+            return ref.clone().startOf("year");
+        case "FinancialApril":
+        case "FinancialJuly":
+        case "FinancialOct":
+        case "FinancialNov": {
+            const monthIndex = financialMonthByName[periodType.replace("Financial", "")];
+            if (monthIndex === undefined) return ref.clone().startOf("day");
+            const thisYearStart = dateFromParts({ year: ref.year(), month: monthIndex, date: 1 });
+            return thisYearStart.isSameOrBefore(ref)
+                ? thisYearStart
+                : thisYearStart.subtract(1, "year");
+        }
+        case "Daily":
+        default:
+            return ref.clone().startOf("day");
+    }
+}

--- a/src/domain/entities/PeriodType.ts
+++ b/src/domain/entities/PeriodType.ts
@@ -1,0 +1,29 @@
+export const knownPeriodTypes = [
+    "Daily",
+    "Weekly",
+    "WeeklyWednesday",
+    "WeeklyThursday",
+    "WeeklySaturday",
+    "WeeklySunday",
+    "BiWeekly",
+    "Monthly",
+    "BiMonthly",
+    "Quarterly",
+    "QuarterlyNov",
+    "SixMonthly",
+    "SixMonthlyApril",
+    "SixMonthlyNov",
+    "Yearly",
+    "FinancialApril",
+    "FinancialJuly",
+    "FinancialOct",
+    "FinancialNov",
+] as const;
+
+export type KnownPeriodType = (typeof knownPeriodTypes)[number];
+
+export type PeriodType = string;
+
+export function isKnownPeriodType(value: string): value is KnownPeriodType {
+    return knownPeriodTypes.some(periodType => periodType === value);
+}

--- a/src/domain/entities/QualityAnalysis.ts
+++ b/src/domain/entities/QualityAnalysis.ts
@@ -1,11 +1,11 @@
 import { Either } from "./generic/Either";
 import { ValidationError } from "./generic/Errors";
 import { Struct } from "./generic/Struct";
-import { validateRequired } from "./generic/validations";
+import { validateDateRange, validateRequired } from "./generic/validations";
 import { Module } from "./Module";
 import { QualityAnalysisSection } from "./QualityAnalysisSection";
 import { QualityAnalysisStatus } from "./QualityAnalysisStatus";
-import { Id } from "./Ref";
+import { DateISOString, Id } from "./Ref";
 import { Sequential } from "./Sequential";
 
 export interface QualityAnalysisAttrs {
@@ -71,12 +71,30 @@ export class QualityAnalysis extends Struct<QualityAnalysisAttrs>() {
                 value: qualityAnalysis.endDate,
             },
             {
+                property: "startDate" as const,
+                errors: validateDateRange(qualityAnalysis.startDate, qualityAnalysis.endDate),
+                value: {
+                    startDate: qualityAnalysis.startDate,
+                    endDate: qualityAnalysis.endDate,
+                },
+            },
+            {
                 property: "status" as const,
                 errors: validateRequired(qualityAnalysis.status),
                 value: qualityAnalysis.status,
             },
             ...countryProperty,
         ].filter(validation => validation.errors.length > 0);
+    }
+
+    // Normalizes a stored boundary to an ISO date. Legacy bare-year values (all
+    // historical data was Yearly, e.g. "2024") become the year's start/end; values
+    // that are already ISO pass through unchanged. No datastore migration: this runs
+    // at the read boundary so legacy and ISO records coexist.
+    static normalizePeriodBoundary(value: string, edge: "start" | "end"): DateISOString {
+        const isBareYear = /^\d{4}$/.test(value);
+        if (!isBareYear) return value;
+        return edge === "start" ? `${value}-01-01` : `${value}-12-31`;
     }
 
     static updateConfiguration(

--- a/src/domain/entities/Settings.ts
+++ b/src/domain/entities/Settings.ts
@@ -10,7 +10,7 @@ export interface SettingsAttrs {
     module: ModuleBase;
     startDate: string;
     countryIds: Id[];
-    usePreviousYear: boolean;
+    usePreviousPeriod: boolean;
 }
 
 export class Settings extends Struct<SettingsAttrs>() {
@@ -23,7 +23,7 @@ export class Settings extends Struct<SettingsAttrs>() {
                 errors: validateRequired(settings.module.id),
                 value: settings.module.id,
             },
-            ...(settings.usePreviousYear
+            ...(settings.usePreviousPeriod
                 ? []
                 : [
                       {

--- a/src/domain/entities/__tests__/DataQualityIssuesProgramConfig.spec.ts
+++ b/src/domain/entities/__tests__/DataQualityIssuesProgramConfig.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+    DataQualityIssuesProgramConfig,
+    DataQualityIssuesProgramConfigAttrs,
+} from "$/domain/entities/DataQualityIssuesProgramConfig";
+import { ValidationErrorKey } from "$/domain/entities/generic/Errors";
+
+const baseAttrs: DataQualityIssuesProgramConfigAttrs = {
+    selectedProgramCode: "PROGRAM",
+    selectedModuleCodes: ["M1", "M2"],
+    selectedModulePeriodTypes: ["Monthly", "Monthly"],
+    defaultSettings: {
+        dataSet: "DS",
+        startDate: "2024-01-01",
+        endDate: "2024-12-31",
+        usePreviousPeriod: false,
+        orgUnits: ["ou1"],
+    },
+    steps: [],
+};
+
+function buildErrorKeys(attrs: DataQualityIssuesProgramConfigAttrs): ValidationErrorKey[] {
+    return DataQualityIssuesProgramConfig.build(attrs).match({
+        error: errors => errors.flatMap(error => error.errors),
+        success: () => [],
+    });
+}
+
+describe("DataQualityIssuesProgramConfig", () => {
+    describe("same-periodType validation", () => {
+        it("does not report mixed_period_type when all datasets share a periodicity", () => {
+            const errorKeys = buildErrorKeys({
+                ...baseAttrs,
+                selectedModulePeriodTypes: ["Monthly", "Monthly"],
+            });
+            expect(errorKeys).not.toContain("mixed_period_type");
+        });
+
+        it("reports mixed_period_type when datasets have different periodicities", () => {
+            const errorKeys = buildErrorKeys({
+                ...baseAttrs,
+                selectedModulePeriodTypes: ["Monthly", "Quarterly"],
+            });
+            expect(errorKeys).toContain("mixed_period_type");
+        });
+
+        it("does not report mixed_period_type when periodicities are not provided (read path)", () => {
+            const errorKeys = buildErrorKeys({
+                ...baseAttrs,
+                selectedModulePeriodTypes: undefined,
+            });
+            expect(errorKeys).not.toContain("mixed_period_type");
+        });
+    });
+});

--- a/src/domain/entities/__tests__/Period.spec.ts
+++ b/src/domain/entities/__tests__/Period.spec.ts
@@ -88,6 +88,16 @@ describe("Period", () => {
             });
         });
 
+        it("includes financial years that overlap (not only those fully contained in) the range", () => {
+            // Range Feb–Dec 2024 straddles two FinancialApril years: 2023April
+            // (Apr 2023 – Mar 2024) and 2024April (Apr 2024 – Mar 2025). Neither is
+            // fully contained in the range, but both intersect it.
+            expect(getPeriodsForRange("FinancialApril", "2024-02-01", "2024-12-31")).toEqual([
+                "2023April",
+                "2024April",
+            ]);
+        });
+
         it("degrades to a date-based (daily) expansion for an unrecognized type (no throw)", () => {
             expect(getPeriodsForRange("SomeFuturePeriodType", "2024-03-01", "2024-03-02")).toEqual([
                 "20240301",

--- a/src/domain/entities/__tests__/Period.spec.ts
+++ b/src/domain/entities/__tests__/Period.spec.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import { getPeriodsForRange, getPreviousPeriod, getPeriodLabel } from "$/domain/entities/Period";
+
+describe("Period", () => {
+    describe("getPeriodsForRange", () => {
+        const cases: Array<{
+            name: string;
+            periodType: string;
+            start: string;
+            end: string;
+            expected: string[];
+        }> = [
+            {
+                name: "Monthly",
+                periodType: "Monthly",
+                start: "2024-01-01",
+                end: "2024-04-30",
+                expected: ["202401", "202402", "202403", "202404"],
+            },
+            {
+                name: "Yearly",
+                periodType: "Yearly",
+                start: "2020-01-01",
+                end: "2024-12-31",
+                expected: ["2020", "2021", "2022", "2023", "2024"],
+            },
+            {
+                name: "Quarterly",
+                periodType: "Quarterly",
+                start: "2024-01-01",
+                end: "2024-12-31",
+                expected: ["2024Q1", "2024Q2", "2024Q3", "2024Q4"],
+            },
+            {
+                name: "Weekly",
+                periodType: "Weekly",
+                start: "2024-01-01",
+                end: "2024-01-14",
+                expected: ["2024W1", "2024W2"],
+            },
+            {
+                name: "SixMonthly",
+                periodType: "SixMonthly",
+                start: "2024-01-01",
+                end: "2024-12-31",
+                expected: ["2024S1", "2024S2"],
+            },
+            {
+                name: "BiMonthly",
+                periodType: "BiMonthly",
+                start: "2024-01-01",
+                end: "2024-12-31",
+                expected: ["202401B", "202402B", "202403B", "202404B", "202405B", "202406B"],
+            },
+            {
+                name: "BiWeekly",
+                periodType: "BiWeekly",
+                start: "2024-01-01",
+                end: "2024-01-28",
+                expected: ["2024BiW1", "2024BiW2"],
+            },
+            {
+                name: "SixMonthlyApril",
+                periodType: "SixMonthlyApril",
+                start: "2024-04-01",
+                end: "2025-03-31",
+                expected: ["2024AprilS1", "2024AprilS2"],
+            },
+            {
+                name: "FinancialApril",
+                periodType: "FinancialApril",
+                start: "2024-04-01",
+                end: "2025-03-31",
+                expected: ["2024April"],
+            },
+            {
+                name: "Daily",
+                periodType: "Daily",
+                start: "2024-03-01",
+                end: "2024-03-03",
+                expected: ["20240301", "20240302", "20240303"],
+            },
+        ];
+
+        cases.forEach(({ name, periodType, start, end, expected }) => {
+            it(`expands a ${name} range into the exact DHIS2 period IDs`, () => {
+                expect(getPeriodsForRange(periodType, start, end)).toEqual(expected);
+            });
+        });
+
+        it("degrades to a date-based (daily) expansion for an unrecognized type (no throw)", () => {
+            expect(getPeriodsForRange("SomeFuturePeriodType", "2024-03-01", "2024-03-02")).toEqual([
+                "20240301",
+                "20240302",
+            ]);
+        });
+
+        it("returns an empty list when a boundary is missing", () => {
+            expect(getPeriodsForRange("Monthly", "", "2024-04-30")).toEqual([]);
+        });
+
+        it("returns an empty list for an inverted range", () => {
+            expect(getPeriodsForRange("Monthly", "2024-04-01", "2024-01-01")).toEqual([]);
+        });
+    });
+
+    describe("getPreviousPeriod", () => {
+        it("returns the previous year for Yearly", () => {
+            expect(getPreviousPeriod("Yearly", new Date("2026-07-15"))).toEqual({
+                startDate: "2025-01-01",
+                endDate: "2025-12-31",
+            });
+        });
+
+        it("returns the previous month for Monthly", () => {
+            expect(getPreviousPeriod("Monthly", new Date("2026-07-15"))).toEqual({
+                startDate: "2026-06-01",
+                endDate: "2026-06-30",
+            });
+        });
+
+        it("returns the previous quarter for Quarterly", () => {
+            expect(getPreviousPeriod("Quarterly", new Date("2026-08-15"))).toEqual({
+                startDate: "2026-04-01",
+                endDate: "2026-06-30",
+            });
+        });
+
+        it("returns the previous ISO week for Weekly", () => {
+            expect(getPreviousPeriod("Weekly", new Date("2026-07-15"))).toEqual({
+                startDate: "2026-07-06",
+                endDate: "2026-07-12",
+            });
+        });
+
+        it("returns the previous semester for SixMonthly", () => {
+            expect(getPreviousPeriod("SixMonthly", new Date("2026-08-15"))).toEqual({
+                startDate: "2026-01-01",
+                endDate: "2026-06-30",
+            });
+        });
+
+        it("falls back to the previous day for an unrecognized type (no throw)", () => {
+            expect(getPreviousPeriod("SomeFuturePeriodType", new Date("2026-07-15"))).toEqual({
+                startDate: "2026-07-14",
+                endDate: "2026-07-14",
+            });
+        });
+    });
+
+    describe("getPeriodLabel", () => {
+        it("formats a monthly id as month and year", () => {
+            expect(getPeriodLabel("Monthly", "202403")).toBe("March 2024");
+        });
+
+        it("formats a quarterly id", () => {
+            expect(getPeriodLabel("Quarterly", "2024Q1")).toBe("Q1 2024");
+        });
+
+        it("uses the raw id as label for uncommon types", () => {
+            expect(getPeriodLabel("SixMonthly", "2024S1")).toBe("2024S1");
+        });
+    });
+});

--- a/src/domain/entities/__tests__/PeriodType.spec.ts
+++ b/src/domain/entities/__tests__/PeriodType.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { isKnownPeriodType } from "$/domain/entities/PeriodType";
+
+describe("PeriodType", () => {
+    describe("isKnownPeriodType", () => {
+        it("recognizes a known type", () => {
+            expect(isKnownPeriodType("Monthly")).toBe(true);
+        });
+
+        it("rejects an unknown type", () => {
+            expect(isKnownPeriodType("SomeFuturePeriodType")).toBe(false);
+        });
+    });
+});

--- a/src/domain/entities/__tests__/QualityAnalysis.spec.ts
+++ b/src/domain/entities/__tests__/QualityAnalysis.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QualityAnalysis, QualityAnalysisAttrs } from "$/domain/entities/QualityAnalysis";
 
 function createQualityAnalysis(data: Partial<QualityAnalysisAttrs>) {
@@ -6,10 +6,17 @@ function createQualityAnalysis(data: Partial<QualityAnalysisAttrs>) {
         ...data,
         status: data.status || "In Progress",
         id: "1",
-        endDate: "2021-01-01",
-        module: { id: "1", code: "1", name: "Module 1", dataElements: [], disaggregations: [] },
+        module: {
+            id: "1",
+            code: "1",
+            name: "Module 1",
+            periodType: "Yearly",
+            dataElements: [],
+            disaggregations: [],
+        },
         name: data.name || "",
-        startDate: "2021-01-01",
+        startDate: data.startDate ?? "2021-01-01",
+        endDate: data.endDate ?? "2021-01-01",
         sections: [],
         lastModification: "",
         countriesAnalysis: [],
@@ -36,5 +43,43 @@ describe("Quality Analysis", () => {
         const fakeUserName = "john";
         const qualityAnalysisName = QualityAnalysis.buildDefaultName("", fakeUserName);
         expect(qualityAnalysisName).toBe(`${fakeUserName} - 2024_01_31_08_22_51_051Z`);
+    });
+
+    describe("normalizePeriodBoundary", () => {
+        it("expands a legacy bare year to the year start / end", () => {
+            expect(QualityAnalysis.normalizePeriodBoundary("2024", "start")).toBe("2024-01-01");
+            expect(QualityAnalysis.normalizePeriodBoundary("2024", "end")).toBe("2024-12-31");
+        });
+
+        it("passes an already-ISO value through unchanged", () => {
+            expect(QualityAnalysis.normalizePeriodBoundary("2024-03-15", "start")).toBe(
+                "2024-03-15"
+            );
+            expect(QualityAnalysis.normalizePeriodBoundary("2024-03-15", "end")).toBe("2024-03-15");
+        });
+    });
+
+    describe("date range validation", () => {
+        it("builds successfully when start date is before end date", () => {
+            const result = createQualityAnalysis({
+                name: "Analysis",
+                startDate: "2024-01-01",
+                endDate: "2024-12-31",
+            });
+            expect(result.isSuccess()).toBe(true);
+        });
+
+        it("fails with date_range_invalid when the range is inverted", () => {
+            const result = createQualityAnalysis({
+                name: "Analysis",
+                startDate: "2024-12-31",
+                endDate: "2024-01-01",
+            });
+            const errorKeys = result.match({
+                error: errors => errors.flatMap(error => error.errors),
+                success: () => [],
+            });
+            expect(errorKeys).toContain("date_range_invalid");
+        });
     });
 });

--- a/src/domain/entities/generic/Errors.ts
+++ b/src/domain/entities/generic/Errors.ts
@@ -9,7 +9,8 @@ export type ValidationErrorKey =
     | "at_least_one_step_required"
     | "duplicate_step_types"
     | "invalid_value"
-    | "at_least_one_disaggregation_required";
+    | "at_least_one_disaggregation_required"
+    | "mixed_period_type";
 
 export const validationErrorMessages: Record<ValidationErrorKey, (fieldName: string) => string> = {
     country_validation: () => i18n.t("Select at least one organisation unit"),
@@ -25,6 +26,8 @@ export const validationErrorMessages: Record<ValidationErrorKey, (fieldName: str
     invalid_value: (fieldName: string) =>
         i18n.t(`Invalid value: {{fieldName}}`, { fieldName: fieldName, nsSeparator: false }),
     at_least_one_disaggregation_required: () => i18n.t("At least one disaggregation is required"),
+    mixed_period_type: () =>
+        i18n.t("All selected datasets must share the same periodicity (period type)"),
 };
 
 export function getErrors<T>(errors: ValidationError<T>[]) {

--- a/src/domain/entities/generic/validations.ts
+++ b/src/domain/entities/generic/validations.ts
@@ -51,3 +51,8 @@ export function validateAtLeastOneDisaggregation(
     const count = disaggregations?.length ?? 0;
     return count > 0 ? [] : ["at_least_one_disaggregation_required"];
 }
+
+export function validateSamePeriodType(periodTypes: string[]): ValidationErrorKey[] {
+    const distinctPeriodTypes = new Set(periodTypes.filter(periodType => periodType.length > 0));
+    return distinctPeriodTypes.size > 1 ? ["mixed_period_type"] : [];
+}

--- a/src/domain/repositories/QualityAnalysisRepository.ts
+++ b/src/domain/repositories/QualityAnalysisRepository.ts
@@ -3,6 +3,7 @@ import { Maybe } from "$/utils/ts-utils";
 import { QualityAnalysis } from "$/domain/entities/QualityAnalysis";
 import { Code, Id } from "$/domain/entities/Ref";
 import { MetadataItem } from "$/domain/entities/MetadataItem";
+import { PeriodType } from "$/domain/entities/PeriodType";
 
 export interface QualityAnalysisRepository {
     get(options: QualityAnalysisOptions): FutureData<QualityAnalysisPaginated>;
@@ -29,6 +30,7 @@ export type QualityAnalysisOptions = {
         startDate: Maybe<string>;
         status: Maybe<string>;
         ids: Maybe<Id[]>;
+        periodType: Maybe<PeriodType>;
     };
     metadata: MetadataItem;
 };

--- a/src/domain/usecases/CreateQualityAnalysisUseCase.ts
+++ b/src/domain/usecases/CreateQualityAnalysisUseCase.ts
@@ -11,8 +11,7 @@ import { SequentialRepository } from "$/domain/repositories/SequentialRepository
 import { SettingsRepository } from "$/domain/repositories/SettingsRepository";
 import { UserRepository } from "$/domain/repositories/UserRepository";
 import { MetadataItem } from "$/domain/entities/MetadataItem";
-
-const previousYear = (new Date().getFullYear() - 1).toString();
+import { getPreviousPeriod } from "$/domain/entities/Period";
 
 export class CreateQualityAnalysisUseCase {
     constructor(
@@ -37,10 +36,14 @@ export class CreateQualityAnalysisUseCase {
                 currentUser.username
             );
 
-            const { endDate, startDate, usePreviousYear, countryIds } = defaultSettings;
+            const { endDate, startDate, usePreviousPeriod, countryIds } = defaultSettings;
+
+            const previousPeriod = usePreviousPeriod
+                ? getPreviousPeriod(options.qualityAnalysis.module.periodType)
+                : undefined;
 
             return QualityAnalysis.build({
-                endDate: usePreviousYear ? previousYear : endDate,
+                endDate: previousPeriod ? previousPeriod.endDate : endDate,
                 id: getUid(`quality-analysis_${new Date().getTime()}`),
                 module: options.qualityAnalysis.module,
                 name: qualityAnalysisName,
@@ -50,7 +53,7 @@ export class CreateQualityAnalysisUseCase {
                         status: QualityAnalysisSection.getInitialStatus(),
                     });
                 }),
-                startDate: usePreviousYear ? previousYear : startDate,
+                startDate: previousPeriod ? previousPeriod.startDate : startDate,
                 status: "In Progress",
                 lastModification: "",
                 countriesAnalysis: countryIds,

--- a/src/domain/usecases/GetMissingDisaggregatesUseCase.ts
+++ b/src/domain/usecases/GetMissingDisaggregatesUseCase.ts
@@ -442,7 +442,9 @@ export class GetMissingDisaggregatesUseCase {
         return this.dataValueUseCase.get(
             analysis.countriesAnalysis,
             [analysis.module.id],
-            [analysis.startDate, analysis.endDate]
+            analysis.module.periodType,
+            analysis.startDate,
+            analysis.endDate
         );
     }
 }

--- a/src/domain/usecases/RunOutlierUseCase.ts
+++ b/src/domain/usecases/RunOutlierUseCase.ts
@@ -28,8 +28,8 @@ export class RunOutlierUseCase {
             .flatMap(analysis => {
                 return this.getOutliers(
                     options,
-                    analysis.startDate,
-                    analysis.endDate,
+                    QualityAnalysis.normalizePeriodBoundary(analysis.startDate, "start"),
+                    QualityAnalysis.normalizePeriodBoundary(analysis.endDate, "end"),
                     analysis.countriesAnalysis,
                     analysis.module.id
                 ).flatMap(outliers => {

--- a/src/domain/usecases/RunPractitionersValidationUseCase.ts
+++ b/src/domain/usecases/RunPractitionersValidationUseCase.ts
@@ -476,7 +476,9 @@ export class RunPractitionersValidationUseCase {
         return this.dataValueUseCase.get(
             qualityAnalysis.countriesAnalysis,
             [qualityAnalysis.module.id],
-            [qualityAnalysis.startDate, qualityAnalysis.endDate]
+            qualityAnalysis.module.periodType,
+            qualityAnalysis.startDate,
+            qualityAnalysis.endDate
         );
     }
 

--- a/src/domain/usecases/RunValidationsUseCase.ts
+++ b/src/domain/usecases/RunValidationsUseCase.ts
@@ -102,8 +102,8 @@ export class RunValidationsUseCase {
             countriesIds.map(countryId =>
                 this.validationRuleAnalysisRepository.get({
                     countryId: countryId,
-                    startDate: `${analysis.startDate}-01-01`,
-                    endDate: `${analysis.endDate}-12-31`,
+                    startDate: QualityAnalysis.normalizePeriodBoundary(analysis.startDate, "start"),
+                    endDate: QualityAnalysis.normalizePeriodBoundary(analysis.endDate, "end"),
                     validationRuleGroupId: options.validationRuleGroupId,
                 })
             ),

--- a/src/domain/usecases/SaveDataQualityIssuesProgramConfigUseCase.ts
+++ b/src/domain/usecases/SaveDataQualityIssuesProgramConfigUseCase.ts
@@ -64,16 +64,19 @@ export const initialState: DataQualityIssuesProgramConfigOptions = {
 function mapToDataQualityIssuesProgramConfig(
     selectedOptions: DataQualityIssuesProgramConfigOptions
 ): Either<ValidationError<DataQualityIssuesProgramConfig>[], DataQualityIssuesProgramConfig> {
+    const { defaultSettings } = selectedOptions;
+    // Coalesce the optional wizard values to empty strings so the entity's
+    // `validateRequired` reports them as missing, instead of forcing the types with `as`.
     return DataQualityIssuesProgramConfig.build({
-        selectedProgramCode: selectedOptions.selectedProgramCode as Code,
+        selectedProgramCode: selectedOptions.selectedProgramCode ?? "",
         selectedModuleCodes: selectedOptions.selectedModuleCodes,
         selectedModulePeriodTypes: selectedOptions.selectedModulePeriodTypes,
         defaultSettings: {
-            dataSet: selectedOptions.defaultSettings.dataSet as Code,
-            startDate: selectedOptions.defaultSettings.startDate as string,
-            endDate: selectedOptions.defaultSettings.endDate as string,
-            orgUnits: selectedOptions.defaultSettings.orgUnits,
-            usePreviousPeriod: selectedOptions.defaultSettings.usePreviousPeriod,
+            dataSet: defaultSettings.dataSet ?? "",
+            startDate: defaultSettings.startDate ?? "",
+            endDate: defaultSettings.endDate ?? "",
+            orgUnits: defaultSettings.orgUnits,
+            usePreviousPeriod: defaultSettings.usePreviousPeriod,
         },
         steps: selectedOptions.steps,
     });

--- a/src/domain/usecases/SaveDataQualityIssuesProgramConfigUseCase.ts
+++ b/src/domain/usecases/SaveDataQualityIssuesProgramConfigUseCase.ts
@@ -32,11 +32,12 @@ export class SaveDataQualityIssuesProgramConfigUseCase {
 export type DataQualityIssuesProgramConfigOptions = {
     selectedProgramCode: Maybe<Code>;
     selectedModuleCodes: Code[];
+    selectedModulePeriodTypes: string[];
     defaultSettings: {
         dataSet: Maybe<Code>;
         endDate: Maybe<string>;
         startDate: Maybe<string>;
-        usePreviousYear: boolean;
+        usePreviousPeriod: boolean;
         orgUnits: Id[];
         orgUnitPaths: string[];
     };
@@ -47,11 +48,12 @@ export type DataQualityIssuesProgramConfigOptions = {
 export const initialState: DataQualityIssuesProgramConfigOptions = {
     selectedProgramCode: undefined,
     selectedModuleCodes: [],
+    selectedModulePeriodTypes: [],
     defaultSettings: {
         dataSet: undefined,
         endDate: undefined,
         startDate: undefined,
-        usePreviousYear: false,
+        usePreviousPeriod: false,
         orgUnits: [],
         orgUnitPaths: [],
     },
@@ -65,12 +67,13 @@ function mapToDataQualityIssuesProgramConfig(
     return DataQualityIssuesProgramConfig.build({
         selectedProgramCode: selectedOptions.selectedProgramCode as Code,
         selectedModuleCodes: selectedOptions.selectedModuleCodes,
+        selectedModulePeriodTypes: selectedOptions.selectedModulePeriodTypes,
         defaultSettings: {
             dataSet: selectedOptions.defaultSettings.dataSet as Code,
             startDate: selectedOptions.defaultSettings.startDate as string,
             endDate: selectedOptions.defaultSettings.endDate as string,
             orgUnits: selectedOptions.defaultSettings.orgUnits,
-            usePreviousYear: selectedOptions.defaultSettings.usePreviousYear,
+            usePreviousPeriod: selectedOptions.defaultSettings.usePreviousPeriod,
         },
         steps: selectedOptions.steps,
     });

--- a/src/domain/usecases/UpdateStatusAnalysisUseCase.ts
+++ b/src/domain/usecases/UpdateStatusAnalysisUseCase.ts
@@ -17,6 +17,7 @@ export class UpdateStatusAnalysisUseCase {
                     name: undefined,
                     startDate: undefined,
                     status: undefined,
+                    periodType: undefined,
                     ids: ids,
                 },
                 pagination: {

--- a/src/domain/usecases/ValidateMidwiferyAndPersonnelUseCase.ts
+++ b/src/domain/usecases/ValidateMidwiferyAndPersonnelUseCase.ts
@@ -354,7 +354,9 @@ export class ValidateMidwiferyAndPersonnelUseCase {
             .get(
                 analysis.countriesAnalysis,
                 [analysis.module.id],
-                [analysis.startDate, analysis.endDate]
+                analysis.module.periodType,
+                analysis.startDate,
+                analysis.endDate
             )
             .flatMap(dataValues => {
                 const dataElementsByKey = _(dataElements)

--- a/src/domain/usecases/common/UCDataValue.ts
+++ b/src/domain/usecases/common/UCDataValue.ts
@@ -2,28 +2,40 @@ import _ from "lodash";
 
 import { FutureData } from "$/data/api-futures";
 import { DataValue } from "$/domain/entities/DataValue";
-import { Id, Period } from "$/domain/entities/Ref";
+import { DateISOString, Id } from "$/domain/entities/Ref";
 import { DataValueRepository } from "$/domain/repositories/DataValueRepository";
 import { Future } from "$/domain/entities/generic/Future";
+import { getPeriodsForRange } from "$/domain/entities/Period";
+import { PeriodType } from "$/domain/entities/PeriodType";
+import { QualityAnalysis } from "$/domain/entities/QualityAnalysis";
 import i18n from "$/utils/i18n";
 
 export class UCDataValue {
     constructor(private dataValueRepository: DataValueRepository) {}
 
-    get(countriesIds: Id[], moduleIds: Id[], periods: Period[]): FutureData<DataValue[]> {
+    get(
+        countriesIds: Id[],
+        moduleIds: Id[],
+        periodType: PeriodType,
+        startDate: DateISOString,
+        endDate: DateISOString
+    ): FutureData<DataValue[]> {
         if (countriesIds.length === 0)
             throw new Error(i18n.t("Select at least one organisation unit"));
 
-        const [startDate, endDate] = periods;
-        if (!startDate || !endDate) throw new Error("Invalid period");
-        const periodsToSearch = _.range(Number(startDate), Number(endDate) + 1);
+        const periodsToSearch = getPeriodsForRange(
+            periodType,
+            QualityAnalysis.normalizePeriodBoundary(startDate, "start"),
+            QualityAnalysis.normalizePeriodBoundary(endDate, "end")
+        );
+        if (periodsToSearch.length === 0) throw new Error("Invalid period");
         const $requests = _(countriesIds)
             .chunk(1)
             .map(countryIds => {
                 return this.dataValueRepository.get({
                     moduleIds: moduleIds,
                     countriesIds: countryIds,
-                    period: periodsToSearch.map(period => String(period)),
+                    period: [...periodsToSearch],
                 });
             })
             .value();

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -1,0 +1,36 @@
+import moment, { Moment } from "moment";
+
+/**
+ * Project-owned date/time utility. This module is the single place in the
+ * codebase that imports `moment` on behalf of the domain layer, so domain code
+ * depends on this wrapper instead of a third-party date library directly. To
+ * swap the underlying implementation, change it here only.
+ */
+
+export type DateTime = Moment;
+
+export type DateDiffUnit = moment.unitOfTime.Diff;
+
+export type DateDurationUnit = moment.unitOfTime.DurationConstructor;
+
+export type DateParts = { year: number; month: number; date: number };
+
+/** Parse a string with an explicit format, optionally in strict mode. */
+export function parseDate(input: string, format: string, strict = false): DateTime {
+    return moment(input, format, strict);
+}
+
+/** Wrap a native `Date` as a `DateTime`. */
+export function dateFromJsDate(date: Date): DateTime {
+    return moment(date);
+}
+
+/** Wrap an existing date-like value (a `DateTime` or native `Date`) as a `DateTime`. */
+export function toDateTime(value: DateTime | Date): DateTime {
+    return moment(value);
+}
+
+/** Build a `DateTime` from calendar parts (month is 0-indexed, as in `moment`). */
+export function dateFromParts(parts: DateParts): DateTime {
+    return moment(parts);
+}

--- a/src/webapp/components/add-issue-dialog/useAddIssueDialog.ts
+++ b/src/webapp/components/add-issue-dialog/useAddIssueDialog.ts
@@ -9,7 +9,7 @@ import _ from "$/domain/entities/generic/Collection";
 import { Maybe } from "$/utils/ts-utils";
 import { IssueTemplate } from "$/domain/usecases/CreateIssueUseCase";
 import { getIdFromCountriesPaths } from "$/webapp/components/configuration-form/ConfigurationForm";
-import { generatePeriodYearOptions } from "$/webapp/utils/form";
+import { getPeriodOptionsForRange } from "$/domain/entities/Period";
 import { useMetadataItemContext } from "$/webapp/contexts/metadata-item-context";
 
 type UseAddIssueDialogProps = {
@@ -67,11 +67,13 @@ export function useAddIssueDialog(props: UseAddIssueDialogProps) {
     }, [dataElementsMap, addIssueForm]);
 
     const periodOptions = React.useMemo(() => {
-        const { startDate, endDate } = analysis;
-        const startYear = parseInt(startDate);
-        const endYear = parseInt(endDate);
-
-        return generatePeriodYearOptions(startYear, endYear);
+        return [
+            ...getPeriodOptionsForRange(
+                analysis.module.periodType,
+                QualityAnalysis.normalizePeriodBoundary(analysis.startDate, "start"),
+                QualityAnalysis.normalizePeriodBoundary(analysis.endDate, "end")
+            ),
+        ];
     }, [analysis]);
 
     const onSave = React.useCallback(() => {

--- a/src/webapp/components/analysis-filter/AnalysisFilter.tsx
+++ b/src/webapp/components/analysis-filter/AnalysisFilter.tsx
@@ -1,17 +1,15 @@
 import React from "react";
 import { Dropdown } from "@eyeseetea/d2-ui-components";
+import styled from "styled-components";
 
 import i18n from "$/utils/i18n";
 import { Module } from "$/domain/entities/Module";
+import { PeriodType } from "$/domain/entities/PeriodType";
 import { qualityAnalysisStatus } from "$/domain/entities/QualityAnalysisStatus";
 import { Maybe } from "$/utils/ts-utils";
 import { MenuButton } from "$/webapp/components/menu-button/MenuButton";
 import { Id } from "$/domain/entities/Ref";
-import { generatePeriodYearOptions } from "$/webapp/utils/form";
-
-const currentYear = new Date().getFullYear();
-
-export const periods = generatePeriodYearOptions(2000, currentYear);
+import { PeriodDateSelector } from "$/webapp/components/period-selector/PeriodDateSelector";
 
 type AnalysisFiltersProps = {
     modules: Module[];
@@ -20,12 +18,19 @@ type AnalysisFiltersProps = {
     onCreateAnalysis: (module: Module) => void;
 };
 
+export function getModulesPeriodType(modules: Module[], selectedModuleId: Maybe<Id>): PeriodType {
+    const selectedModule = modules.find(module => module.id === selectedModuleId);
+    return selectedModule?.periodType ?? modules[0]?.periodType ?? "";
+}
+
 export const AnalysisFilters: React.FC<AnalysisFiltersProps> = props => {
     const { modules, initialFilters, onChange, onCreateAnalysis } = props;
 
     const modulesFilters = modules.map(module => {
         return { value: module.id, text: module.name };
     });
+
+    const filterPeriodType: PeriodType = getModulesPeriodType(modules, initialFilters.module);
 
     const analysisStatus = qualityAnalysisStatus.map(status => {
         return { value: status, text: status };
@@ -54,18 +59,27 @@ export const AnalysisFilters: React.FC<AnalysisFiltersProps> = props => {
                 value={initialFilters.module}
                 label={i18n.t("Dataset")}
             />
-            <Dropdown
-                items={periods}
-                onChange={value => onFilterChange(value, "startDate")}
-                value={initialFilters.startDate}
-                label={i18n.t("Start Date")}
-            />
-            <Dropdown
-                items={periods}
-                onChange={value => onFilterChange(value, "endDate")}
-                value={initialFilters.endDate}
-                label={i18n.t("End Date")}
-            />
+
+            <PeriodDateSelectorContainer>
+                <PeriodDateSelector
+                    label={i18n.t("Start Date")}
+                    periodType={filterPeriodType}
+                    edge="start"
+                    value={initialFilters.startDate ?? ""}
+                    onChange={value => onFilterChange(value, "startDate")}
+                />
+            </PeriodDateSelectorContainer>
+
+            <PeriodDateSelectorContainer>
+                <PeriodDateSelector
+                    label={i18n.t("End Date")}
+                    periodType={filterPeriodType}
+                    edge="end"
+                    value={initialFilters.endDate ?? ""}
+                    onChange={value => onFilterChange(value, "endDate")}
+                />
+            </PeriodDateSelectorContainer>
+
             <Dropdown
                 items={analysisStatus}
                 onChange={value => onFilterChange(value, "status")}
@@ -97,3 +111,11 @@ export const initialFilters: AnalysisFilterState = {
     startDate: undefined,
     status: undefined,
 };
+
+const PeriodDateSelectorContainer = styled.div`
+    margin-inline-start: 10px;
+
+    > div {
+        margin-block-end: 24px;
+    }
+`;

--- a/src/webapp/components/analysis-filter/__tests__/AnalysisFilter.spec.ts
+++ b/src/webapp/components/analysis-filter/__tests__/AnalysisFilter.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { getModulesPeriodType } from "$/webapp/components/analysis-filter/AnalysisFilter";
+import { Module } from "$/domain/entities/Module";
+
+function buildModule(id: string, periodType: string): Module {
+    return {
+        id,
+        name: `Module ${id}`,
+        code: `M${id}`,
+        periodType,
+        dataElements: [],
+        disaggregations: [],
+    };
+}
+
+describe("getModulesPeriodType", () => {
+    it("returns the periodType of the module matching the selected Dataset filter", () => {
+        const modules = [buildModule("1", "Yearly"), buildModule("2", "Yearly")];
+
+        const result = getModulesPeriodType(modules, "2");
+
+        expect(result).toBe("Yearly");
+    });
+
+    it("falls back to any configured module's periodType when no Dataset filter is selected", () => {
+        const modules = [buildModule("1", "Yearly"), buildModule("2", "Yearly")];
+
+        const result = getModulesPeriodType(modules, undefined);
+
+        expect(result).toBe("Yearly");
+    });
+
+    it("falls back to any configured module's periodType when the selected id matches no module", () => {
+        const modules = [buildModule("1", "Monthly")];
+
+        const result = getModulesPeriodType(modules, "missing-id");
+
+        expect(result).toBe("Monthly");
+    });
+
+    it("defaults to free date (empty periodType) when no module is configured at all", () => {
+        const result = getModulesPeriodType([], undefined);
+
+        expect(result).toBe("");
+    });
+});

--- a/src/webapp/components/configuration-form/ConfigurationForm.tsx
+++ b/src/webapp/components/configuration-form/ConfigurationForm.tsx
@@ -5,8 +5,9 @@ import { Dropdown, OrgUnitsSelector } from "@eyeseetea/d2-ui-components";
 import i18n from "$/utils/i18n";
 import { useAppContext } from "$/webapp/contexts/app-context";
 import { QualityAnalysis } from "$/domain/entities/QualityAnalysis";
+import { validateDateRange } from "$/domain/entities/generic/validations";
 import { Maybe } from "$/utils/ts-utils";
-import { periods } from "$/webapp/components/analysis-filter/AnalysisFilter";
+import { PeriodDateSelector } from "$/webapp/components/period-selector/PeriodDateSelector";
 import { Id } from "$/domain/entities/Ref";
 import _ from "$/domain/entities/generic/Collection";
 import styled from "styled-components";
@@ -51,12 +52,16 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = React.memo(pr
             if (!formData) return undefined;
             if (!inputRef.current?.value) return undefined;
             if (formData) {
-                const newValue = QualityAnalysis.build({
+                QualityAnalysis.build({
                     ...formData,
                     name: inputRef.current.value,
                     countriesAnalysis: getIdFromCountriesPaths(selectedOrgUnits),
-                }).get();
-                onSave(newValue);
+                }).match({
+                    success: onSave,
+                    // Nothing to do: the inline Start/End Date Alert already reports
+                    // date_range_invalid, and the Save button is disabled while it holds.
+                    error: () => undefined,
+                });
             }
         },
         [formData, onSave, selectedOrgUnits]
@@ -66,10 +71,14 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = React.memo(pr
         const selectedModule = modules.find(module => module.id === value);
         if (selectedModule) {
             setFormData(prev => {
-                return QualityAnalysis.build({
+                const candidate = {
                     ...prev,
                     module: { ...selectedModule, dataElements: [], disaggregations: [] },
-                }).get();
+                };
+                return QualityAnalysis.build(candidate).match({
+                    success: qualityAnalysis => qualityAnalysis,
+                    error: () => new QualityAnalysis(candidate),
+                });
             });
         }
     };
@@ -77,9 +86,16 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = React.memo(pr
     const onChangePeriod = (value: Maybe<string>, attributeName: string) => {
         if (!value) return false;
         setFormData(prev => {
-            return QualityAnalysis.build({ ...prev, [attributeName]: value }).get();
+            const candidate = { ...prev, [attributeName]: value };
+            return QualityAnalysis.build(candidate).match({
+                success: qualityAnalysis => qualityAnalysis,
+                error: () => new QualityAnalysis(candidate),
+            });
         });
     };
+
+    const dateRangeErrors = validateDateRange(formData.startDate, formData.endDate);
+    const hasDateRangeError = dateRangeErrors.length > 0;
 
     const onOrgUnitsChange = (value: Id[]) => {
         setSelectedOrgUnits(value);
@@ -95,6 +111,14 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = React.memo(pr
                 <AlertContainer>
                     <Alert severity="error">
                         {i18n.t("Select at least one organisation unit")}
+                    </Alert>
+                </AlertContainer>
+            )}
+
+            {hasDateRangeError && (
+                <AlertContainer>
+                    <Alert severity="error">
+                        {i18n.t("Start Date must not be later than End Date")}
                     </Alert>
                 </AlertContainer>
             )}
@@ -116,23 +140,31 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = React.memo(pr
                         label={i18n.t("Module")}
                     />
 
-                    <Dropdown
-                        className={selectorClass}
-                        hideEmpty
-                        items={periods}
-                        onChange={value => onChangePeriod(value, "startDate")}
-                        value={formData?.startDate}
-                        label={i18n.t("Start Date")}
-                    />
+                    <PeriodDateSelectorContainer>
+                        <PeriodDateSelector
+                            className={selectorClass}
+                            label={i18n.t("Start Date")}
+                            periodType={formData.module.periodType}
+                            edge="start"
+                            value={formData?.startDate ?? ""}
+                            onChange={value => onChangePeriod(value, "startDate")}
+                            disabled={disableSave}
+                            clearable={false}
+                        />
+                    </PeriodDateSelectorContainer>
 
-                    <Dropdown
-                        className={selectorClass}
-                        hideEmpty
-                        items={periods}
-                        onChange={value => onChangePeriod(value, "endDate")}
-                        value={formData?.endDate}
-                        label={i18n.t("End Date")}
-                    />
+                    <PeriodDateSelectorContainer>
+                        <PeriodDateSelector
+                            className={selectorClass}
+                            label={i18n.t("End Date")}
+                            periodType={formData.module.periodType}
+                            edge="end"
+                            value={formData?.endDate ?? ""}
+                            onChange={value => onChangePeriod(value, "endDate")}
+                            disabled={disableSave}
+                            clearable={false}
+                        />
+                    </PeriodDateSelectorContainer>
                 </DropdownWrapper>
             </FormControlsContainer>
 
@@ -149,7 +181,12 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = React.memo(pr
             </OrgUnitContainer>
 
             <ActionsContainer>
-                <Button type="submit" variant="contained" color="primary">
+                <Button
+                    type="submit"
+                    variant="contained"
+                    color="primary"
+                    disabled={hasDateRangeError}
+                >
                     {i18n.t("Save Config Analysis")}
                 </Button>
             </ActionsContainer>
@@ -178,6 +215,7 @@ const FormControlsContainer = styled.div`
 const DropdownWrapper = styled.div`
     display: flex;
     gap: 1rem;
+    align-items: flex-end;
 `;
 
 const StyledTextField = styled(TextField)`
@@ -196,4 +234,10 @@ const ActionsContainer = styled.div`
 
 const AlertContainer = styled.div`
     margin-block: 1em;
+`;
+
+const PeriodDateSelectorContainer = styled.div`
+    > div {
+        margin-block-end: 0px;
+    }
 `;

--- a/src/webapp/components/issues/IssueColumns.tsx
+++ b/src/webapp/components/issues/IssueColumns.tsx
@@ -6,8 +6,10 @@ import i18n from "$/utils/i18n";
 import { EditIssueValue } from "./EditIssueValue";
 import { useMetadataItemContext } from "$/webapp/contexts/metadata-item-context";
 import { hasUserGroups } from "$/webapp/components/issues/utils";
+import { PeriodType } from "$/domain/entities/PeriodType";
+import { getPeriodLabel } from "$/domain/entities/Period";
 
-export function useIssueColumns() {
+export function useIssueColumns(periodType: PeriodType) {
     const { metadataItem } = useMetadataItemContext();
 
     const [refresh, setRefresh] = React.useState(0);
@@ -20,7 +22,7 @@ export function useIssueColumns() {
                 name: "period",
                 text: i18n.t("Period"),
                 sortable: false,
-                getValue: value => value.period,
+                getValue: value => (value.period ? getPeriodLabel(periodType, value.period) : ""),
             },
             { name: "dataElement", text: i18n.t("Data Element"), sortable: false },
             {
@@ -150,7 +152,7 @@ export function useIssueColumns() {
         ];
 
         return hasUserGroups(metadataItem.userGroups) ? columnsWithContactEmails : baseColumns;
-    }, [metadataItem.userGroups]);
+    }, [metadataItem.userGroups, periodType]);
 
     return { refresh, setRefresh, issueColumns };
 }

--- a/src/webapp/components/issues/IssueFilters.tsx
+++ b/src/webapp/components/issues/IssueFilters.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 
-import { Id, Period } from "$/domain/entities/Ref";
+import { DateISOString, Id, Period } from "$/domain/entities/Ref";
+import { PeriodType } from "$/domain/entities/PeriodType";
+import { getPeriodOptionsForRange } from "$/domain/entities/Period";
 import { GetIssuesOptions } from "$/domain/repositories/IssueRepository";
 import { SelectMultiCheckboxes } from "$/webapp/components/selectmulti-checkboxes/SelectMultiCheckboxes";
-import { periods } from "$/webapp/components/analysis-filter/AnalysisFilter";
 import { Maybe } from "$/utils/ts-utils";
 import i18n from "$/utils/i18n";
 import { useAppContext } from "$/webapp/contexts/app-context";
@@ -50,7 +51,8 @@ export const IssueFilters: React.FC<IssueFiltersProps> = props => {
     const { metadataItem } = useMetadataItemContext();
 
     const snackbar = useSnackbar();
-    const { initialFilters, onChange, showStepFilter } = props;
+    const { initialFilters, onChange, showStepFilter, periodType, rangeStartDate, rangeEndDate } =
+        props;
     const [openCountry, setOpenCountry] = React.useState(false);
     const [selectedCountriesIds, setSelectedCountriesIds] = React.useState<Id[]>([]);
     const [countries, setCountries] = React.useState<Country[]>([]);
@@ -75,6 +77,11 @@ export const IssueFilters: React.FC<IssueFiltersProps> = props => {
     const step = metadataItem.programs.qualityIssues.programStages.map((option, index) => {
         return { value: String(index + 1), text: option.name };
     });
+
+    const periodOptions = React.useMemo(
+        () => getPeriodOptionsForRange(periodType, rangeStartDate, rangeEndDate),
+        [periodType, rangeStartDate, rangeEndDate]
+    );
 
     const onClickCountry = () => {
         setOpenCountry(true);
@@ -141,7 +148,7 @@ export const IssueFilters: React.FC<IssueFiltersProps> = props => {
             <SelectMultiCheckboxes
                 label={i18n.t("Periods")}
                 onChange={values => onFilterChange(values, "periods")}
-                options={periods}
+                options={[...periodOptions]}
                 value={initialFilters.periods}
             />
 
@@ -181,6 +188,9 @@ type IssueFiltersProps = {
     initialFilters: IssueFilterState;
     onChange: React.Dispatch<React.SetStateAction<GetIssuesOptions["filters"]>>;
     showStepFilter?: boolean;
+    periodType: PeriodType;
+    rangeStartDate: DateISOString;
+    rangeEndDate: DateISOString;
 };
 
 export type IssueFilterState = {

--- a/src/webapp/components/issues/IssueTable.tsx
+++ b/src/webapp/components/issues/IssueTable.tsx
@@ -244,6 +244,7 @@ function useAnalysisPeriodInfo(analysisId: Id): {
 } {
     const { compositionRoot } = useAppContext();
     const { metadataItem } = useMetadataItemContext();
+    const snackbar = useSnackbar();
     const [info, setInfo] = React.useState<{
         periodType: PeriodType;
         startDate: DateISOString;
@@ -258,9 +259,15 @@ function useAnalysisPeriodInfo(analysisId: Id): {
                     startDate: analysis.startDate,
                     endDate: analysis.endDate,
                 }),
-            () => {}
+            error =>
+                snackbar.error(
+                    i18n.t("Could not load analysis period information: {{message}}", {
+                        message: error.message,
+                        nsSeparator: false,
+                    })
+                )
         );
-    }, [analysisId, compositionRoot.qualityAnalysis.getById, metadataItem]);
+    }, [analysisId, compositionRoot.qualityAnalysis.getById, metadataItem, snackbar]);
 
     return info;
 }

--- a/src/webapp/components/issues/IssueTable.tsx
+++ b/src/webapp/components/issues/IssueTable.tsx
@@ -11,7 +11,8 @@ import { useAppContext } from "$/webapp/contexts/app-context";
 import { QualityAnalysisIssue } from "$/domain/entities/QualityAnalysisIssue";
 import { GetIssuesOptions } from "$/domain/repositories/IssueRepository";
 import i18n from "$/utils/i18n";
-import { Id } from "$/domain/entities/Ref";
+import { DateISOString, Id } from "$/domain/entities/Ref";
+import { PeriodType } from "$/domain/entities/PeriodType";
 import { IssueFilters } from "./IssueFilters";
 import { initialFilters } from "$/webapp/utils/issues";
 import { Maybe } from "$/utils/ts-utils";
@@ -95,8 +96,8 @@ export function useExportIssues() {
 }
 
 export function useTableConfig(props: UseTableConfigProps) {
-    const { analysisId, filters, sectionId, showExport } = props;
-    const { issueColumns, refresh, setRefresh } = useIssueColumns();
+    const { analysisId, filters, periodType, sectionId, showExport } = props;
+    const { issueColumns, refresh, setRefresh } = useIssueColumns(periodType);
     const { metadataItem } = useMetadataItemContext();
 
     const { saveColumns, columnsToShow } = useTableUtils<QualityAnalysisIssue>({
@@ -236,13 +237,43 @@ export function useGetRows(
     return { getRows, loading };
 }
 
+function useAnalysisPeriodInfo(analysisId: Id): {
+    periodType: PeriodType;
+    startDate: DateISOString;
+    endDate: DateISOString;
+} {
+    const { compositionRoot } = useAppContext();
+    const { metadataItem } = useMetadataItemContext();
+    const [info, setInfo] = React.useState<{
+        periodType: PeriodType;
+        startDate: DateISOString;
+        endDate: DateISOString;
+    }>({ periodType: "Yearly", startDate: "", endDate: "" });
+
+    React.useEffect(() => {
+        compositionRoot.qualityAnalysis.getById.execute(analysisId, metadataItem).run(
+            analysis =>
+                setInfo({
+                    periodType: analysis.module.periodType,
+                    startDate: analysis.startDate,
+                    endDate: analysis.endDate,
+                }),
+            () => {}
+        );
+    }, [analysisId, compositionRoot.qualityAnalysis.getById, metadataItem]);
+
+    return info;
+}
+
 export const IssueTable: React.FC<IssueTableProps> = React.memo(props => {
     const { analysisId, reload, sectionId, showExport, showStepFilter } = props;
     const [filters, setFilters] = React.useState(initialFilters);
+    const analysisPeriodInfo = useAnalysisPeriodInfo(analysisId);
 
     const { tableConfig, refresh } = useTableConfig({
         filters,
         analysisId: analysisId,
+        periodType: analysisPeriodInfo.periodType,
         sectionId: sectionId,
         showExport: showExport,
         showStepFilter: showStepFilter,
@@ -256,9 +287,12 @@ export const IssueTable: React.FC<IssueTableProps> = React.memo(props => {
                 initialFilters={filters}
                 showStepFilter={showStepFilter}
                 onChange={setFilters}
+                periodType={analysisPeriodInfo.periodType}
+                rangeStartDate={analysisPeriodInfo.startDate}
+                rangeEndDate={analysisPeriodInfo.endDate}
             />
         );
-    }, [filters, showStepFilter]);
+    }, [filters, showStepFilter, analysisPeriodInfo]);
 
     return (
         <ObjectsTable
@@ -281,6 +315,7 @@ type IssueTableProps = {
 type UseTableConfigProps = {
     analysisId: Id;
     filters: GetIssuesOptions["filters"];
+    periodType: PeriodType;
     sectionId: Maybe<Id>;
     showExport?: boolean;
     showStepFilter?: boolean;

--- a/src/webapp/components/period-selector/PeriodDateSelector.tsx
+++ b/src/webapp/components/period-selector/PeriodDateSelector.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { DatePicker } from "@eyeseetea/d2-ui-components";
+
+import { DateISOString } from "$/domain/entities/Ref";
+import { PeriodType } from "$/domain/entities/PeriodType";
+import { parseDate, toDateTime } from "$/utils/dates";
+import { getPeriodPickerFormat } from "./periodPickerFormat";
+
+const ISO_DATE = "YYYY-MM-DD";
+
+export type PeriodDateSelectorProps = {
+    label: string;
+    periodType: PeriodType;
+    value: DateISOString;
+    edge: "start" | "end";
+    onChange: (isoDate: DateISOString) => void;
+    minDate?: DateISOString;
+    maxDate?: DateISOString;
+    disabled?: boolean;
+    className?: string;
+    clearable?: boolean;
+};
+
+export const PeriodDateSelector: React.FC<PeriodDateSelectorProps> = React.memo(props => {
+    const {
+        label,
+        periodType,
+        value,
+        edge,
+        onChange,
+        minDate,
+        maxDate,
+        disabled,
+        className,
+        clearable,
+    } = props;
+
+    const { unit, views, format } = getPeriodPickerFormat(periodType);
+
+    const dateValue = value ? parseDate(value, ISO_DATE) : null;
+
+    return (
+        <DatePicker
+            className={className}
+            label={label}
+            value={dateValue}
+            onChange={date => {
+                const parsed = date ? toDateTime(date) : null;
+                if (!parsed || !parsed.isValid()) {
+                    onChange("");
+                    return;
+                }
+                const snapped =
+                    edge === "start" ? parsed.clone().startOf(unit) : parsed.clone().endOf(unit);
+                onChange(snapped.format(ISO_DATE));
+            }}
+            views={[...views]}
+            format={format}
+            minDate={minDate ? parseDate(minDate, ISO_DATE) : undefined}
+            maxDate={maxDate ? parseDate(maxDate, ISO_DATE) : undefined}
+            disabled={disabled}
+            clearable={clearable}
+        />
+    );
+});

--- a/src/webapp/components/period-selector/__tests__/periodPickerFormat.spec.ts
+++ b/src/webapp/components/period-selector/__tests__/periodPickerFormat.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { getPeriodPickerFormat } from "$/webapp/components/period-selector/periodPickerFormat";
+
+describe("getPeriodPickerFormat", () => {
+    it("returns a year picker for Yearly", () => {
+        expect(getPeriodPickerFormat("Yearly")).toEqual({
+            unit: "year",
+            views: ["year"],
+            format: "YYYY",
+        });
+    });
+
+    it("returns a month+year picker for Monthly", () => {
+        expect(getPeriodPickerFormat("Monthly")).toEqual({
+            unit: "month",
+            views: ["year", "month"],
+            format: "MMMM YYYY",
+        });
+    });
+
+    it("returns a free date picker for a known non-yearly/monthly type (Quarterly)", () => {
+        expect(getPeriodPickerFormat("Quarterly")).toEqual({
+            unit: "date",
+            views: ["year", "month", "date"],
+            format: "YYYY-MM-DD",
+        });
+    });
+
+    it("falls through to the free date picker for an unrecognized/future type", () => {
+        expect(getPeriodPickerFormat("SomeFuturePeriodType")).toEqual({
+            unit: "date",
+            views: ["year", "month", "date"],
+            format: "YYYY-MM-DD",
+        });
+    });
+});

--- a/src/webapp/components/period-selector/periodPickerFormat.ts
+++ b/src/webapp/components/period-selector/periodPickerFormat.ts
@@ -1,0 +1,20 @@
+import { PeriodType } from "$/domain/entities/PeriodType";
+
+export type PeriodPickerView = "year" | "month" | "date";
+
+export type PeriodPickerFormat = {
+    unit: PeriodPickerView;
+    views: ReadonlyArray<PeriodPickerView>;
+    format: string;
+};
+
+export function getPeriodPickerFormat(periodType: PeriodType): PeriodPickerFormat {
+    switch (periodType) {
+        case "Yearly":
+            return { unit: "year", views: ["year"], format: "YYYY" };
+        case "Monthly":
+            return { unit: "month", views: ["year", "month"], format: "MMMM YYYY" };
+        default:
+            return { unit: "date", views: ["year", "month", "date"], format: "YYYY-MM-DD" };
+    }
+}

--- a/src/webapp/hooks/useModulesOptions.ts
+++ b/src/webapp/hooks/useModulesOptions.ts
@@ -8,6 +8,7 @@ import { Option } from "$/webapp/entities/Option";
 
 type State = {
     modulesOptions: Option[];
+    modules: ModuleBase[];
 };
 
 export function useModulesOptions(): State {
@@ -49,5 +50,6 @@ export function useModulesOptions(): State {
 
     return {
         modulesOptions: modulesOptions,
+        modules: modules ?? [],
     };
 }

--- a/src/webapp/hooks/useQualityAnalysisTable.ts
+++ b/src/webapp/hooks/useQualityAnalysisTable.ts
@@ -5,7 +5,10 @@ import i18n from "$/utils/i18n";
 import { QualityAnalysis } from "$/domain/entities/QualityAnalysis";
 import { useAppContext } from "$/webapp/contexts/app-context";
 import { analysisColumns } from "$/webapp/utils/analysis";
-import { AnalysisFilterState } from "$/webapp/components/analysis-filter/AnalysisFilter";
+import {
+    AnalysisFilterState,
+    getModulesPeriodType,
+} from "$/webapp/components/analysis-filter/AnalysisFilter";
 import {
     ActionType,
     useAnalysisTableActions,
@@ -40,7 +43,7 @@ export function useTableConfig(props: UseTableConfigProps) {
     return { tableConfig };
 }
 
-export function useGetRows(filters: AnalysisFilterState, reloadKey: number) {
+export function useGetRows(filters: AnalysisFilterState, reloadKey: number, modules: Module[]) {
     const { compositionRoot } = useAppContext();
     const { metadataItem } = useMetadataItemContext();
 
@@ -60,6 +63,7 @@ export function useGetRows(filters: AnalysisFilterState, reloadKey: number) {
                             startDate: filters.startDate,
                             status: filters.status,
                             module: filters.module,
+                            periodType: getModulesPeriodType(modules, filters.module),
                             ids: undefined,
                         },
                         metadata: metadataItem,
@@ -85,6 +89,7 @@ export function useGetRows(filters: AnalysisFilterState, reloadKey: number) {
             filters.module,
             filters.startDate,
             filters.status,
+            modules,
             reloadKey,
             metadataItem,
         ]

--- a/src/webapp/pages/config-program/hooks/useConfigProgram.tsx
+++ b/src/webapp/pages/config-program/hooks/useConfigProgram.tsx
@@ -20,6 +20,8 @@ import { StepSettings } from "$/domain/entities/StepSettings";
 import { DataQualityIssuesProgramConfig } from "$/domain/entities/DataQualityIssuesProgramConfig";
 import { Maybe } from "$/utils/ts-utils";
 import { Country } from "$/domain/entities/Country";
+import { PeriodType } from "$/domain/entities/PeriodType";
+import { validateSamePeriodType } from "$/domain/entities/generic/validations";
 
 type StepKey =
     | "program-selection"
@@ -44,7 +46,7 @@ export function useConfigProgram(): State {
     }>();
     const { compositionRoot } = useAppContext();
     const { qualityIssuesPrograms } = useQualityIssuesPrograms();
-    const { modulesOptions } = useModulesOptions();
+    const { modulesOptions, modules } = useModulesOptions();
 
     const isEdit = Boolean(qualityIssuesProgramCode);
 
@@ -166,6 +168,22 @@ export function useConfigProgram(): State {
         );
     }, [moduleOptionsAvailable, configProgramState?.selectedModuleCodes]);
 
+    const periodTypeByCode = React.useMemo<Record<Code, PeriodType>>(() => {
+        return Object.fromEntries(modules.map(module => [module.code, module.periodType]));
+    }, [modules]);
+
+    const selectedModulePeriodTypes = React.useMemo<PeriodType[]>(() => {
+        const codes = configProgramState?.selectedModuleCodes ?? [];
+        return codes
+            .map(code => periodTypeByCode[code])
+            .filter((periodType): periodType is PeriodType => Boolean(periodType));
+    }, [configProgramState?.selectedModuleCodes, periodTypeByCode]);
+
+    const defaultDataSetPeriodType = React.useMemo<PeriodType>(() => {
+        const dataSet = configProgramState?.defaultSettings?.dataSet;
+        return (dataSet ? periodTypeByCode[dataSet] : undefined) ?? "Yearly";
+    }, [configProgramState?.defaultSettings?.dataSet, periodTypeByCode]);
+
     const sections = useMemo(() => {
         return (
             qualityIssuesPrograms?.find(
@@ -178,20 +196,23 @@ export function useConfigProgram(): State {
         if (!configProgramState) return;
 
         loading.show(true, i18n.t("Saving configuration..."));
-        compositionRoot.dataQualityIssuesProgramConfig.save.execute(configProgramState).run(
-            () => {
-                loading.hide();
-                snackBar.success(`Configuration saved successfully`);
-                history.push("/settings");
-            },
-            err => {
-                loading.hide();
-                snackBar.error(`Error saving configuration: ${err.message}`);
-            }
-        );
+        compositionRoot.dataQualityIssuesProgramConfig.save
+            .execute({ ...configProgramState, selectedModulePeriodTypes })
+            .run(
+                () => {
+                    loading.hide();
+                    snackBar.success(`Configuration saved successfully`);
+                    history.push("/settings");
+                },
+                err => {
+                    loading.hide();
+                    snackBar.error(`Error saving configuration: ${err.message}`);
+                }
+            );
     }, [
         compositionRoot.dataQualityIssuesProgramConfig.save,
         configProgramState,
+        selectedModulePeriodTypes,
         history,
         loading,
         snackBar,
@@ -235,6 +256,7 @@ export function useConfigProgram(): State {
                     selectedModuleOptions,
                     values: configProgramState.defaultSettings,
                     onChange: updateDefaultSettings,
+                    defaultDataSetPeriodType,
                 },
             },
             {
@@ -266,6 +288,7 @@ export function useConfigProgram(): State {
         programOptions,
         onSaveConfiguration,
         selectedModuleOptions,
+        defaultDataSetPeriodType,
         updateConfig,
         updateDefaultSettings,
         sections,
@@ -291,17 +314,26 @@ export function useConfigProgram(): State {
                 if (!configProgramState?.selectedModuleCodes?.length) {
                     errors = [...errors, i18n.t("Select at least one Dataset")];
                 }
+
+                if (validateSamePeriodType(selectedModulePeriodTypes).length > 0) {
+                    errors = [
+                        ...errors,
+                        i18n.t(
+                            "All selected datasets must share the same periodicity (period type)"
+                        ),
+                    ];
+                }
             }
 
             if (stepKey === "default-settings") {
-                const { dataSet, startDate, endDate, usePreviousYear } =
+                const { dataSet, startDate, endDate, usePreviousPeriod } =
                     configProgramState?.defaultSettings ?? {};
 
                 if (!dataSet) {
                     errors = [...errors, i18n.t("Select a default dataset")];
                 }
 
-                if (!usePreviousYear) {
+                if (!usePreviousPeriod) {
                     if (!startDate) {
                         errors = [...errors, i18n.t("Select a start date")];
                     }
@@ -333,6 +365,7 @@ export function useConfigProgram(): State {
             configProgramState?.selectedModuleCodes?.length,
             configProgramState?.selectedProgramCode,
             configProgramState?.steps,
+            selectedModulePeriodTypes,
         ]
     );
 
@@ -362,11 +395,12 @@ function getDataQualityIssuesProgramConfigOptions(
     return {
         selectedProgramCode: config.selectedProgramCode,
         selectedModuleCodes: config.selectedModuleCodes,
+        selectedModulePeriodTypes: config.selectedModulePeriodTypes ?? [],
         defaultSettings: {
             dataSet: config.defaultSettings.dataSet,
             endDate: config.defaultSettings.endDate,
             startDate: config.defaultSettings.startDate,
-            usePreviousYear: config.defaultSettings.usePreviousYear,
+            usePreviousPeriod: config.defaultSettings.usePreviousPeriod,
             orgUnits: config.defaultSettings.orgUnits,
             orgUnitPaths: countries?.map(country => country.path) ?? [],
         },

--- a/src/webapp/pages/config-program/steps/3-default-settings/DefaultSettingsStep.tsx
+++ b/src/webapp/pages/config-program/steps/3-default-settings/DefaultSettingsStep.tsx
@@ -4,31 +4,26 @@ import styled from "styled-components";
 import { Dropdown, OrgUnitsSelector } from "@eyeseetea/d2-ui-components";
 
 import i18n from "$/utils/i18n";
-import {
-    generatePeriodYearOptions,
-    ORG_UNIT_LEVELS,
-    ORG_UNIT_SELECTABLE_LEVELS,
-} from "$/webapp/utils/form";
+import { ORG_UNIT_LEVELS, ORG_UNIT_SELECTABLE_LEVELS } from "$/webapp/utils/form";
 import { DataQualityIssuesProgramConfigOptions } from "$/domain/usecases/SaveDataQualityIssuesProgramConfigUseCase";
 import { useAppContext } from "$/webapp/contexts/app-context";
 import { Id } from "$/domain/entities/Ref";
+import { PeriodType } from "$/domain/entities/PeriodType";
 import { CheckboxInline } from "$/webapp/components/issues/CheckboxInline";
 import { getIdFromCountriesPaths } from "$/webapp/components/configuration-form/ConfigurationForm";
+import { PeriodDateSelector } from "$/webapp/components/period-selector/PeriodDateSelector";
 import { Option } from "$/webapp/entities/Option";
 
 type Props = {
     values: DataQualityIssuesProgramConfigOptions["defaultSettings"];
     onChange: (patch: Partial<DataQualityIssuesProgramConfigOptions["defaultSettings"]>) => void;
     selectedModuleOptions: Option[];
+    defaultDataSetPeriodType: PeriodType;
 };
-
-const currentYear = new Date().getFullYear();
-
-const periods = generatePeriodYearOptions(2000, currentYear);
 
 export const DefaultSettingsStep: React.FC<Props> = React.memo(props => {
     const { api, currentUser } = useAppContext();
-    const { values, onChange, selectedModuleOptions } = props;
+    const { values, onChange, selectedModuleOptions, defaultDataSetPeriodType } = props;
 
     const onOrgUnitsChange = React.useCallback(
         (paths: Id[]) => {
@@ -38,12 +33,12 @@ export const DefaultSettingsStep: React.FC<Props> = React.memo(props => {
         [onChange]
     );
 
-    const onUsePreviousYearChange = React.useCallback(
+    const onUsePreviousPeriodChange = React.useCallback(
         (checked: boolean) => {
             if (checked) {
-                onChange({ usePreviousYear: true, startDate: "", endDate: "" });
+                onChange({ usePreviousPeriod: true, startDate: "", endDate: "" });
             } else {
-                onChange({ usePreviousYear: false });
+                onChange({ usePreviousPeriod: false });
             }
         },
         [onChange]
@@ -63,27 +58,29 @@ export const DefaultSettingsStep: React.FC<Props> = React.memo(props => {
             <FieldsContainer>
                 <CheckboxContainer>
                     <CheckboxInline
-                        value={values.usePreviousYear}
-                        onChange={onUsePreviousYearChange}
+                        value={values.usePreviousPeriod}
+                        onChange={onUsePreviousPeriodChange}
                     />
-                    <span>{i18n.t("Use previous year for start and end dates")}</span>
+                    <span>{i18n.t("Use previous period for start and end dates")}</span>
                 </CheckboxContainer>
 
-                <DisabledWrapper disabled={values.usePreviousYear}>
-                    <Dropdown
-                        items={periods}
-                        onChange={value => onChange({ startDate: value })}
-                        value={values.startDate}
+                <DisabledWrapper disabled={values.usePreviousPeriod}>
+                    <PeriodDateSelector
                         label={i18n.t("Start Date")}
+                        periodType={defaultDataSetPeriodType}
+                        edge="start"
+                        value={values.startDate ?? ""}
+                        onChange={value => onChange({ startDate: value })}
                     />
                 </DisabledWrapper>
 
-                <DisabledWrapper disabled={values.usePreviousYear}>
-                    <Dropdown
-                        items={periods}
-                        onChange={value => onChange({ endDate: value })}
-                        value={values.endDate}
+                <DisabledWrapper disabled={values.usePreviousPeriod}>
+                    <PeriodDateSelector
                         label={i18n.t("End Date")}
+                        periodType={defaultDataSetPeriodType}
+                        edge="end"
+                        value={values.endDate ?? ""}
+                        onChange={value => onChange({ endDate: value })}
                     />
                 </DisabledWrapper>
             </FieldsContainer>

--- a/src/webapp/pages/config-program/steps/5-summary/SummaryStep.tsx
+++ b/src/webapp/pages/config-program/steps/5-summary/SummaryStep.tsx
@@ -69,9 +69,9 @@ export const SummaryStep: React.FC<Props> = React.memo(props => {
                                 {i18n.t("Dataset: ", { nsSeparator: false })} {defaultModule}
                             </li>
 
-                            {configProgramState.defaultSettings.usePreviousYear ? (
+                            {configProgramState.defaultSettings.usePreviousPeriod ? (
                                 <li key={configProgramState.defaultSettings.endDate}>
-                                    {i18n.t("Use previous year for start and end dates")}
+                                    {i18n.t("Use previous period for start and end dates")}
                                 </li>
                             ) : (
                                 <>

--- a/src/webapp/pages/dashboard/DashboardPage.tsx
+++ b/src/webapp/pages/dashboard/DashboardPage.tsx
@@ -64,9 +64,9 @@ export const DashboardPage: React.FC = React.memo(() => {
         ),
     });
 
-    const { getRows, loading } = useGetRows(filters, reload);
-
     const modules = useModules();
+
+    const { getRows, loading } = useGetRows(filters, reload, modules);
 
     const config = useObjectsTable(tableConfig, getRows);
 

--- a/src/webapp/utils/analysis.tsx
+++ b/src/webapp/utils/analysis.tsx
@@ -25,8 +25,18 @@ function mapAnalysisStatusToColor(sectionStatus: string) {
 export const analysisColumns: TableColumn<QualityAnalysis>[] = [
     { name: "name", text: i18n.t("Name"), sortable: true },
     { name: "module", text: i18n.t("Dataset"), sortable: true },
-    { name: "startDate", text: i18n.t("Start Date"), sortable: true },
-    { name: "endDate", text: i18n.t("End Date"), sortable: true },
+    {
+        name: "startDate",
+        text: i18n.t("Start Date"),
+        sortable: true,
+        getValue: row => row.startDate,
+    },
+    {
+        name: "endDate",
+        text: i18n.t("End Date"),
+        sortable: true,
+        getValue: row => row.endDate,
+    },
     {
         name: "status",
         text: i18n.t("Status"),

--- a/src/webapp/utils/form.ts
+++ b/src/webapp/utils/form.ts
@@ -1,11 +1,2 @@
-import { Collection } from "$/domain/entities/generic/Collection";
-
 export const ORG_UNIT_LEVELS = [1, 2, 3];
 export const ORG_UNIT_SELECTABLE_LEVELS = [2, 3];
-
-export function generatePeriodYearOptions(startYear: number, endYear: number) {
-    return Collection.range(startYear, endYear + 1)
-        .map(year => ({ value: year.toString(), text: year.toString() }))
-        .reverse()
-        .value();
-}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #869dek93h [Issues/Bugs detected during Webinar prep](https://app.clickup.com/t/869dek93h)

### :memo: Implementation
- Issues (events in the program) have the data value of Period and now we will store a DHIS2 period type key instead of only the year (Yearly  → "2024" as it was before this change, Monthly  → "202607" ...)
- the start and end date (TEAs) in the quality analysis (TEI) now they must be valueType DATE instead of TEXT and now stores ISO dates ("2024" → "2024-01-01"). No migration script; records upgrade lazily on edit.
- In default settings: `usePreviousYear` → `usePreviousPeriod` in Datastore rename with deprecated-key read priority and save-drop of the old key; backward-compatible.
- Filters:
  - In Data Quality Analysis Setup step Default Analysis Settings, Start/End date: allows to select Years if Dataset is Yearly, Months if is Monthly and any full date if others
  - In the configuration step of a new data quality report, Start/End date: allows to select Years if Dataset is Yearly, Months if is Monthly and any full date if others
  - In the issues table, Periods has the options according to the period type of the datasets analysed


### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester
- test existing Data Quality Analysis to test backward-compatible

- Program to test: test it adding datasets with different period types, more than one dataset can be added to a Data quality Analisys Location but only if they have the same period type
[NEW_TEST_PROGRAM_DATE.json](https://github.com/user-attachments/files/30093411/NEW_TEST_PROGRAM_DATE.json)

- Program to test the setup error message: now Start/End dates with valueType DATE is required (not TEXT)
[NEW_TEST_PROGRAM_TEXT.json](https://github.com/user-attachments/files/30093416/NEW_TEST_PROGRAM_TEXT.json)

