### PR TITLE
fix(app): avoid double header bar when installed in DHIS2

### DIFF
--- a/src/webapp/components/header-bar/HeaderBar.tsx
+++ b/src/webapp/components/header-bar/HeaderBar.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import styled from "styled-components";
+import { HeaderBar as D2HeaderBar } from "@dhis2/ui";
+
+type HeaderBarProps = {
+    appName: string;
+};
+
+// avoid rendering header for versions > 2.41
+// https://developers.dhis2.org/docs/references/global-shell/#header-bars
+export const HeaderBar: React.FC<HeaderBarProps> = props => {
+    const { appName } = props;
+    const shouldRenderHeaderBar = window.self === window.top;
+    return shouldRenderHeaderBar ? <StyledHeaderBar appName={appName} /> : null;
+};
+
+const StyledHeaderBar = styled(D2HeaderBar)`
+    div:first-of-type {
+        box-sizing: border-box;
+    }
+`;

--- a/src/webapp/components/header-bar/__tests__/HeaderBar.spec.tsx
+++ b/src/webapp/components/header-bar/__tests__/HeaderBar.spec.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "@dhis2/app-runtime";
+
+import { HeaderBar } from "$/webapp/components/header-bar/HeaderBar";
+
+describe("HeaderBar", () => {
+    it("renders the DHIS2 header bar when the app is not embedded in an iframe", () => {
+        getView();
+
+        expect(screen.getByRole("banner")).toBeInTheDocument();
+    });
+
+    it("does not render the DHIS2 header bar when the app is embedded in an iframe", () => {
+        const originalTop = window.top;
+        Object.defineProperty(window, "top", { value: {}, configurable: true });
+
+        getView();
+
+        expect(screen.queryByRole("banner")).toBeNull();
+
+        Object.defineProperty(window, "top", { value: originalTop, configurable: true });
+    });
+});
+
+function getView() {
+    return render(
+        <Provider config={{ baseUrl: "http://localhost:8080", apiVersion: 30 }}>
+            <HeaderBar appName="Data Quality" />
+        </Provider>
+    );
+}

--- a/src/webapp/pages/app/App.tsx
+++ b/src/webapp/pages/app/App.tsx
@@ -1,4 +1,3 @@
-import { HeaderBar } from "@dhis2/ui";
 import { SnackbarProvider } from "@eyeseetea/d2-ui-components";
 import { Feedback } from "@eyeseetea/feedback-component";
 import { MuiThemeProvider } from "@material-ui/core/styles";
@@ -9,6 +8,7 @@ import React, { useEffect, useState } from "react";
 import { appConfig } from "$/app-config";
 import { CompositionRoot } from "$/CompositionRoot";
 import Share from "$/webapp/components/share/Share";
+import { HeaderBar } from "$/webapp/components/header-bar/HeaderBar";
 import { AppContext, AppContextState } from "$/webapp/contexts/app-context";
 import { Router } from "$/webapp/pages/Router";
 import "./App.css";


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #869dvn096 [Fix double header bar](https://app.clickup.com/t/4528615/869dvn096)

### :memo: Implementation
- DHIS2's global shell (>2.41) renders its own header bar when the app is embedded in an iframe, duplicating the HeaderBar this app already renders. Only render it when the app is loaded at the top level.

### :video_camera: Screenshots/Screen capture
<img width="867" height="471" alt="image" src="https://github.com/user-attachments/assets/fd8f5bcd-79f7-4d79-8066-57fc72901286" />


### :fire: Notes to the tester
Build the app install and check
Check also running it in local env